### PR TITLE
Unifying `Dataset` API.

### DIFF
--- a/training/tests/datasets/test_dataset.py
+++ b/training/tests/datasets/test_dataset.py
@@ -13,5 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
+from pathlib import Path
+from unittest import TestCase
 
-from xtime.datasets.dataset import Dataset, DatasetBuilder, DatasetMetadata, DatasetSplit
+from xtime.contrib.unittest_ext import with_temp_work_dir
+from xtime.datasets.dataset import Dataset, DatasetBuilder, DatasetMetadata, DatasetSplit, build_dataset
+
+
+class TestDataset(TestCase):
+    @with_temp_work_dir
+    def test_save_load(self) -> None:
+        ds: Dataset = build_dataset("churn_modelling:default")
+        self.assertEqual(ds.metadata.name, "churn_modelling")
+        self.assertEqual(ds.metadata.version, "default")
+
+        ds.save(Path.cwd())
+        loaded_ds: Dataset = Dataset.load(Path.cwd())
+
+        self.assertDictEqual(ds.metadata.to_json(), loaded_ds.metadata.to_json())
+        self.assertEqual(sorted(list(ds.splits.keys())), sorted(list(loaded_ds.splits.keys())))
+
+        # TODO: add unit tests for features and targets

--- a/training/xtime/stages/search_hp.py
+++ b/training/xtime/stages/search_hp.py
@@ -32,7 +32,7 @@ from ray.tune.search.hyperopt import HyperOptSearch
 import xtime.hparams as hp
 from xtime.contrib.mlflow_ext import MLflow
 from xtime.contrib.tune_ext import Analysis, RayTuneDriverToMLflowLoggerCallback
-from xtime.datasets import Dataset
+from xtime.datasets import Dataset, build_dataset
 from xtime.estimators import Estimator, get_estimator
 from xtime.hparams import HParamsSource, get_hparams
 from xtime.io import IO, encode
@@ -64,8 +64,8 @@ def search_hp(
         artifact_path: Path = MLflow.get_artifact_path(active_run)
         run_id: str = active_run.info.run_id
 
-        ctx = Context(Metadata(dataset=dataset, model=model, run_type=RunType.HPO))
-        Dataset.load(ctx, save_info_dir=artifact_path)
+        ctx = Context(Metadata(dataset=dataset, model=model, run_type=RunType.HPO), dataset=build_dataset(dataset))
+        IO.save_yaml(ctx.dataset.metadata.to_json(), artifact_path / "dataset_info.yaml")
         _set_tags(
             dataset=dataset,
             model=model,


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Previously, the load method had totally different semantics compared to its save counterpart. This commit fixes it - the `save` method dumps datasets to disk, while the `load` method restores datasets from disk. The old method was used in one place, and its usage has been fixed.

# What changes are proposed in this pull request?

- [ ] Bug fix.
- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, new and existing unit tests pass locally with my changes.
- [ ] `NA` I have [signed-off](https://wiki.linuxfoundation.org/dco) my pull request.
