### PR TITLE
Fixing the use of Pandas StringMethods.split method.

### DIFF
--- a/training/xtime/datasets/_rossmann_store_sales.py
+++ b/training/xtime/datasets/_rossmann_store_sales.py
@@ -61,7 +61,7 @@ class RossmannStoreSalesBuilder(DatasetBuilder):
         train["StateHoliday"].replace(0, "n", inplace=True)
 
         # Convert Date column (e.g., 2015-07-31) into three integer columns - year, month and day
-        train[["Year", "Month", "Day"]] = train["Date"].str.split("-", 3, expand=True).astype(int)
+        train[["Year", "Month", "Day"]] = train["Date"].str.split(pat="-", n=3, expand=True).astype(int)
         train.drop(["Date"], axis=1, inplace=True)
 
         # Join with store table


### PR DESCRIPTION
# Related Issues / Pull Requests

#6 

# Description

In 2.0.0, only the first parameter can be positional, all others must be key-value paramters. This commit fixes it. No tests have been performed with pandas 2.0.0 though.

# What changes are proposed in this pull request?

- [x] Bug fix.
- [ ] New feature.


# Checklist:

- [ ] `NA` My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [ ] `NA` I have commented my code.
- [ ] `NA` I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, new and existing unit tests pass locally with my changes.
- [ ] `NA` I have [signed-off](https://wiki.linuxfoundation.org/dco) my pull request.
