### PR TITLE
Fix: invalid TinyDB query generation

### DIFF
--- a/training/tests/hparams/test_recommender.py
+++ b/training/tests/hparams/test_recommender.py
@@ -13,5 +13,111 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
+import typing as t
+from unittest import TestCase
 
-from xtime.hparams.recommender import DefaultRecommender
+from xtime.datasets import Dataset, DatasetMetadata
+from xtime.hparams import get_hparams
+from xtime.ml import ClassificationTask, RegressionTask, Task, TaskType
+from xtime.run import Context, Metadata, RunType
+
+TaskLike = t.TypeVar("TaskLike", bound=Task)
+
+
+class TestRecommender(TestCase):
+    @staticmethod
+    def _get_context(model: str, task: TaskLike) -> Context:
+        return Context(
+            metadata=Metadata(dataset="iris", model=model, run_type=RunType.TRAIN),
+            dataset=Dataset(metadata=DatasetMetadata(name="iris", version="0.0.1", task=task)),
+        )
+
+    def test_default_lightgbm(self):
+        params: t.Dict = get_hparams(
+            source="default",
+            ctx=self._get_context(
+                "lightgbm", ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=3)
+            ),
+        )
+        self.assertIsInstance(params, dict)
+        self.assertDictEqual(
+            params,
+            {
+                "n_estimators": 100,
+                "learning_rate": 0.3,
+                "max_depth": 6,
+                "colsample_bytree": 1,
+                "reg_alpha": 0,
+                "reg_lambda": 1,
+                "random_state": 1,
+            },
+        )
+
+    def test_default_dummy_classifier(self):
+        params: t.Dict = get_hparams(
+            source="default",
+            ctx=self._get_context(
+                "dummy", ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=3)
+            ),
+        )
+        self.assertIsInstance(params, dict)
+        self.assertDictEqual(params, {"strategy": "prior", "random_state": 1})
+
+    def test_default_dummy_regressor(self):
+        params: t.Dict = get_hparams(source="default", ctx=self._get_context("dummy", RegressionTask()))
+        self.assertIsInstance(params, dict)
+        self.assertDictEqual(params, {"strategy": "mean"})
+
+    def test_default_rf(self):
+        params: t.Dict = get_hparams(
+            source="default",
+            ctx=self._get_context("rf", ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=3)),
+        )
+        self.assertIsInstance(params, dict)
+        self.assertDictEqual(params, {"n_estimators": 100, "max_depth": 6, "random_state": 1})
+
+    def test_default_catboost(self):
+        params: t.Dict = get_hparams(
+            source="default",
+            ctx=self._get_context(
+                "catboost", ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=3)
+            ),
+        )
+        self.assertIsInstance(params, dict)
+        self.assertDictEqual(
+            params,
+            {
+                "learning_rate": 0.03,
+                "random_strength": 1,
+                "depth": 6,
+                "l2_leaf_reg": 3,
+                "bagging_temperature": 1,
+                "leaf_estimation_iterations": 1,
+                "random_state": 1,
+            },
+        )
+
+    def test_default_xgboost(self):
+        params: t.Dict = get_hparams(
+            source="default",
+            ctx=self._get_context(
+                "xgboost", ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=3)
+            ),
+        )
+        self.assertIsInstance(params, dict)
+        self.assertDictEqual(
+            params,
+            {
+                "n_estimators": 100,
+                "learning_rate": 0.3,
+                "max_depth": 6,
+                "subsample": 1,
+                "colsample_bytree": 1,
+                "colsample_bylevel": 1,
+                "min_child_weight": 1,
+                "reg_alpha": 0,
+                "reg_lambda": 1,
+                "gamma": 0,
+                "random_state": 1,
+            },
+        )

--- a/training/xtime/hparams/_hparams.py
+++ b/training/xtime/hparams/_hparams.py
@@ -126,18 +126,18 @@ def get_hparams(source: t.Optional[HParamsSource] = None, ctx: t.Optional[Contex
                 hp = {}
             else:
                 from tinydb import Query
-
                 from xtime.hparams.recommender import DefaultRecommender
 
-                print(ctx.metadata.model, ctx.dataset.metadata.task)
-                q = Query()
-                q = q.tags.model == ctx.metadata.model and q.tags.tasks.any([ctx.dataset.metadata.task.type.value])
+                query = Query()
+                query = (query.tags.model == ctx.metadata.model)
+                if ctx.dataset and ctx.dataset.metadata.task:
+                    query = query & Query().tags.tasks.any([ctx.dataset.metadata.task.type.value])
                 recommender = DefaultRecommender()
 
                 if ctx.metadata.run_type == RunType.TRAIN:
-                    recommendations: t.List[t.Dict] = recommender.recommend_default_values(q)
+                    recommendations: t.List[t.Dict] = recommender.recommend_default_values(query)
                 elif ctx.metadata.run_type == RunType.HPO:
-                    recommendations: t.List[t.Dict] = recommender.recommend_search_space(q)
+                    recommendations: t.List[t.Dict] = recommender.recommend_search_space(query)
                 else:
                     raise ValueError(f"Unknown run_type={ctx.metadata.run_type}")
 


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit fixes one bug related to generating query in TinyDB format that is used to retrieve default hyperparameters for models and tasks. Search query (that is supposed to introduce constraints on model names and task types) was constructed using the wrong python API what was resulting in model type not being taken into account. This does not impact results published in the paper (since this implementation was added later, and back then default hyperparameters (which were exactly the same) were being retrieved using a different mechanism).

# What changes are proposed in this pull request?

- [x] Bug fix.
- [ ] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, new and existing unit tests pass locally with my changes.
- [ ] I have [signed-off](https://wiki.linuxfoundation.org/dco) my pull request.
