### PR TITLE
BugFix: accessing metrics dictionary using invalid key.

### DIFF
--- a/training/xtime/estimators/estimator.py
+++ b/training/xtime/estimators/estimator.py
@@ -81,7 +81,7 @@ class MLflowCallback(Callback):
         MLflow.set_tags(task=dataset.metadata.task)
 
     def after_test(self, dataset: Dataset, estimator: "Estimator", metrics: t.Dict) -> None:
-        mlflow.log_metrics({name: float(metrics[name]) for name in METRICS[dataset.metadata.task]})
+        mlflow.log_metrics({name: float(metrics[name]) for name in METRICS[dataset.metadata.task.type]})
 
 
 class TrainCallback(Callback):


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit fixes a bug in the `MLflowCallback.after_test` callback method.

# What changes are proposed in this pull request?

- [x] Bug fix.
- [ ] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [ ] I have commented my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If applicable, new and existing unit tests pass locally with my changes.
- [ ] I have [signed-off](https://wiki.linuxfoundation.org/dco) my pull request.
