### PR TITLE
Adding pydantic version constraint to requirements file.

### DIFF
--- a/training/requirements.txt
+++ b/training/requirements.txt
@@ -17,3 +17,5 @@ requests == 2.28.2            # core dependency
 tinydb == 4.7.1               # core dependency
 
 prettytable == 3.6.0          # command line interface
+
+pydantic < 2                  # indirect dependency (why here: https://github.com/aws/aws-sdk-pandas/issues/2379)


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Ray tune conflicts with latest pydantic (project indirect dependency) versions. Version that needs to be installed < 2.

# What changes are proposed in this pull request?

- [x] Bug fix.
- [ ] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [ ] I have commented my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If applicable, new and existing unit tests pass locally with my changes.
- [ ] I have [signed-off](https://wiki.linuxfoundation.org/dco) my pull request.
