### PR TITLE
Better hyperparameter support

### DIFF
--- a/training/tests/contrib/test_tune_ext.py
+++ b/training/tests/contrib/test_tune_ext.py
@@ -13,5 +13,153 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
+import typing as t
+from unittest import TestCase
 
-from xtime.contrib.tune_ext import Analysis, gpu_available
+import ray.tune.search.sample as sample
+import yaml
+
+from xtime.contrib.tune_ext import (
+    Analysis,
+    RandomVarDomain,
+    RayTuneDriverToMLflowLoggerCallback,
+    add_representers,
+    gpu_available,
+)
+
+
+class TestYamlRepresenters(TestCase):
+    """
+    Here, `rv` stands for random variable.
+    """
+
+    def setUp(self) -> None:
+        add_representers()
+
+    def test_integer_domain(self) -> None:
+        """Test serialization/deserialization for integer domain (`Integer`)."""
+        self._test_uniform_samplers(sample.Integer)
+
+    def test_float_domain(self) -> None:
+        """Test serialization/deserialization for floating point domain (`Float`)."""
+        self._test_uniform_samplers(sample.Float)
+        self._test_normal_samplers()
+
+    def test_categorical_domain(self) -> None:
+        """Test serialization/deserialization for categorical domain (`Categorical`)."""
+        cats = ["Garfield", "Tom Cat", "Puss in Boots"]
+
+        def _check(_rv: sample.Categorical, _sampler_t: t.Optional[t.Type]) -> None:
+            self.assertIsInstance(_rv, sample.Categorical)
+            self.assertListEqual(cats, _rv.categories)
+            self._check_sampler(type(_rv), _rv.sampler, sampler_type=_sampler_t)
+
+        _check(_rv=self._dump_load(sample.choice(cats)), _sampler_t=sample.Categorical._Uniform)
+        _check(_rv=self._dump_load(sample.Categorical(cats)), _sampler_t=None)
+        _check(_rv=self._dump_load(sample.Categorical(cats).uniform()), _sampler_t=sample.Categorical._Uniform)
+        _check(_rv=self._dump_load(sample.Categorical(cats).grid()), _sampler_t=sample.Grid)
+
+    def _dump_load(self, rv: RandomVarDomain) -> RandomVarDomain:
+        """Serialize and then deserialize random variable specification."""
+        serialized_rv: str = yaml.dump(rv, Dumper=yaml.SafeDumper)
+        self.assertIsInstance(serialized_rv, str)
+
+        deserialized_rv = yaml.load(serialized_rv, Loader=yaml.SafeLoader)
+        self.assertIsInstance(deserialized_rv, type(rv))
+
+        return deserialized_rv
+
+    def _check_object_type(self, obj: t.Any, expected_type: t.Optional[t.Type]) -> None:
+        if expected_type is None:
+            self.assertIsNone(obj)
+        else:
+            self.assertIsInstance(obj, expected_type)
+
+    def _test_uniform_samplers(self, domain_t: t.Union[t.Type[sample.Integer], t.Type[sample.Float]]) -> None:
+        lower, upper, base, q = (10, 100, 6, 2)
+
+        self.assertIn(domain_t, {sample.Integer, sample.Float}, "Invalid domain type.")
+
+        def _check(
+            _rv: sample.Domain, _sampler_t: t.Optional[t.Type], _q: t.Optional = None, _base: t.Optional = None
+        ) -> None:
+            self.assertIsInstance(_rv, domain_t)
+            self.assertEqual(lower, _rv.lower)
+            self.assertEqual(upper, _rv.upper)
+            self._check_sampler(type(_rv), _rv.sampler, sampler_type=_sampler_t, q=_q, base=_base)
+
+        _check(self._dump_load(domain_t(lower, upper)), None, None, None)
+        _check(self._dump_load(domain_t(lower, upper).uniform()), domain_t._Uniform, None, None)
+        _check(self._dump_load(domain_t(lower, upper).loguniform(base)), domain_t._LogUniform, None, base)
+        _check(self._dump_load(domain_t(lower, upper).uniform().quantized(q)), domain_t._Uniform, q, None)
+        _check(self._dump_load(domain_t(lower, upper).loguniform(base).quantized(q)), domain_t._LogUniform, q, base)
+
+        if domain_t is sample.Integer:
+            random, log_random, q_random, q_log_random = (
+                sample.randint,
+                sample.lograndint,
+                sample.qrandint,
+                sample.qlograndint,
+            )
+        else:
+            random, log_random, q_random, q_log_random = (
+                sample.uniform,
+                sample.loguniform,
+                sample.quniform,
+                sample.qloguniform,
+            )
+
+        _check(self._dump_load(random(lower, upper)), domain_t._Uniform, None, None)
+        _check(self._dump_load(log_random(lower, upper, base)), domain_t._LogUniform, None, base)
+        _check(self._dump_load(q_random(lower, upper, q)), domain_t._Uniform, q, None)
+        _check(self._dump_load(q_log_random(lower, upper, q, base)), domain_t._LogUniform, q, base)
+
+    def _test_normal_samplers(self) -> None:
+        domain_t = sample.Float
+        mean, sd = 1.1, 0.45
+        q = 0.1
+
+        def _check(_rv: sample.Float, _sampler_t: t.Optional[t.Type], _q: t.Optional = None) -> None:
+            self.assertEqual(float("-inf"), _rv.lower)
+            self.assertEqual(float("+inf"), _rv.upper)
+            self._check_sampler(type(_rv), _rv.sampler, sampler_type=_sampler_t, q=_q, mean=mean, sd=sd)
+
+        _check(self._dump_load(domain_t(None, None).normal(mean, sd)), domain_t._Normal, None)
+        _check(self._dump_load(domain_t(None, None).normal(mean, sd).quantized(q)), domain_t._Normal, q)
+
+        _check(self._dump_load(sample.randn(mean, sd)), domain_t._Normal, None)
+        _check(self._dump_load(sample.qrandn(mean, sd, q)), domain_t._Normal, q)
+
+    def _check_sampler(
+        self,
+        rv_type: t.Type,
+        sampler: t.Optional[sample.Sampler],
+        sampler_type: t.Optional[t.Type] = None,
+        base: t.Optional[int] = None,
+        q: t.Optional[int] = None,
+        mean: t.Optional[float] = None,
+        sd: t.Optional[float] = None,
+    ) -> None:
+        if q is not None:
+            #
+            self.assertIsNotNone(sampler_type, "Quantized sampler requires another sampler.")
+            #
+            self.assertIsInstance(sampler, sample.Quantized)
+            self.assertEqual(q, sampler.q)
+            sampler = sampler.sampler
+
+        self._check_object_type(sampler, sampler_type)
+
+        if rv_type is sample.Categorical or sampler is None or isinstance(sampler, sample.Uniform):
+            return
+
+        if isinstance(sampler, sample.LogUniform):
+            self.assertEqual(base, sampler.base)
+            return
+
+        if isinstance(sampler, sample.Normal):
+            self.assertEqual(mean, sampler.mean)
+            self.assertEqual(sd, sampler.sd)
+            return
+
+        self.assertTrue(False, f"Unexpected sampler: {sampler}.")

--- a/training/tests/hparams/test_recommender.py
+++ b/training/tests/hparams/test_recommender.py
@@ -16,29 +16,16 @@
 import typing as t
 from unittest import TestCase
 
-from xtime.datasets import Dataset, DatasetMetadata
 from xtime.hparams import get_hparams
-from xtime.ml import ClassificationTask, RegressionTask, Task, TaskType
-from xtime.run import Context, Metadata, RunType
+from xtime.ml import Task
 
 TaskLike = t.TypeVar("TaskLike", bound=Task)
 
 
 class TestRecommender(TestCase):
-    @staticmethod
-    def _get_context(model: str, task: TaskLike) -> Context:
-        return Context(
-            metadata=Metadata(dataset="iris", model=model, run_type=RunType.TRAIN),
-            dataset=Dataset(metadata=DatasetMetadata(name="iris", version="0.0.1", task=task)),
-        )
 
     def test_default_lightgbm(self):
-        params: t.Dict = get_hparams(
-            source="default",
-            ctx=self._get_context(
-                "lightgbm", ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=3)
-            ),
-        )
+        params: t.Dict = get_hparams("auto:default:model=lightgbm;task=multi_class_classification")
         self.assertIsInstance(params, dict)
         self.assertDictEqual(
             params,
@@ -54,35 +41,22 @@ class TestRecommender(TestCase):
         )
 
     def test_default_dummy_classifier(self):
-        params: t.Dict = get_hparams(
-            source="default",
-            ctx=self._get_context(
-                "dummy", ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=3)
-            ),
-        )
+        params: t.Dict = get_hparams("auto:default:model=dummy;task=multi_class_classification")
         self.assertIsInstance(params, dict)
         self.assertDictEqual(params, {"strategy": "prior", "random_state": 1})
 
     def test_default_dummy_regressor(self):
-        params: t.Dict = get_hparams(source="default", ctx=self._get_context("dummy", RegressionTask()))
+        params: t.Dict = get_hparams("auto:default:model=dummy;task=regression")
         self.assertIsInstance(params, dict)
         self.assertDictEqual(params, {"strategy": "mean"})
 
     def test_default_rf(self):
-        params: t.Dict = get_hparams(
-            source="default",
-            ctx=self._get_context("rf", ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=3)),
-        )
+        params: t.Dict = get_hparams("auto:default:model=rf;task=multi_class_classification")
         self.assertIsInstance(params, dict)
         self.assertDictEqual(params, {"n_estimators": 100, "max_depth": 6, "random_state": 1})
 
     def test_default_catboost(self):
-        params: t.Dict = get_hparams(
-            source="default",
-            ctx=self._get_context(
-                "catboost", ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=3)
-            ),
-        )
+        params: t.Dict = get_hparams("auto:default:model=catboost;task=multi_class_classification")
         self.assertIsInstance(params, dict)
         self.assertDictEqual(
             params,
@@ -98,12 +72,7 @@ class TestRecommender(TestCase):
         )
 
     def test_default_xgboost(self):
-        params: t.Dict = get_hparams(
-            source="default",
-            ctx=self._get_context(
-                "xgboost", ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=3)
-            ),
-        )
+        params: t.Dict = get_hparams("auto:default:model=xgboost;task=multi_class_classification")
         self.assertIsInstance(params, dict)
         self.assertDictEqual(
             params,

--- a/training/tests/test_cli.py
+++ b/training/tests/test_cli.py
@@ -96,7 +96,7 @@ class TestMain(TestCase):
                 "--params",
                 "params:n_estimators=ValueSpec(int, 100, tune.randint(100, 4001))",
             ],
-            ["--params", "default", "--ctx", 'model="xgboost";task="multi_class_classification";num_classes=5'],
+            ["--params", "auto:default:model=xgboost;task='multi_class_classification'"],
         ]
         for cmd_args in args:
             result: Result = CliRunner().invoke(hparams_query, cmd_args)

--- a/training/xtime/estimators/estimator.py
+++ b/training/xtime/estimators/estimator.py
@@ -45,14 +45,11 @@ __all__ = ["Estimator", "get_estimator_registry", "get_estimator", "unit_test_tr
 
 
 class Callback(object):
-    def before_fit(self, dataset: Dataset, estimator: "Estimator") -> None:
-        ...
+    def before_fit(self, dataset: Dataset, estimator: "Estimator") -> None: ...
 
-    def after_fit(self, dataset: Dataset, estimator: "Estimator") -> None:
-        ...
+    def after_fit(self, dataset: Dataset, estimator: "Estimator") -> None: ...
 
-    def after_test(self, dataset: Dataset, estimator: "Estimator", metrics: t.Dict) -> None:
-        ...
+    def after_test(self, dataset: Dataset, estimator: "Estimator", metrics: t.Dict) -> None: ...
 
 
 class ContainerCallback(Callback):
@@ -104,13 +101,14 @@ class TrainCallback(Callback):
     def before_fit(self, dataset: Dataset, estimator: "Estimator") -> None:
         IO.save_yaml(dataset.metadata.to_json(), (self.work_dir / self.data_info_file).as_posix())
         IO.save_yaml(
-            {
+            data={
                 "estimator": {"cls": estimator.__class__.__name__, "params": encode(estimator.params)},
                 "hparams": self.hparams,
                 "context": self.context,
                 "env": {"cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES", None)},
             },
-            (self.work_dir / self.run_info_file).as_posix(),
+            file_path=self.work_dir / self.run_info_file,
+            raise_on_error=False,
         )
 
     def after_fit(self, dataset: Dataset, estimator: "Estimator") -> None:
@@ -126,12 +124,10 @@ class Estimator(object):
         self.model = None
 
     @abc.abstractmethod
-    def save_model(self, save_dir: Path) -> None:
-        ...
+    def save_model(self, save_dir: Path) -> None: ...
 
     @abc.abstractmethod
-    def fit_model(self, dataset: Dataset, **kwargs) -> None:
-        ...
+    def fit_model(self, dataset: Dataset, **kwargs) -> None: ...
 
     @classmethod
     def fit(cls, hparams: t.Dict, ctx: Context) -> t.Dict:

--- a/training/xtime/hparams/__init__.py
+++ b/training/xtime/hparams/__init__.py
@@ -21,8 +21,8 @@ from ._hparams import (
     HParamsSpec,
     JsonEncoder,
     ValueSpec,
+    from_auto,
     from_file,
-    from_list,
     from_mlflow,
     from_string,
     get_hparams,
@@ -37,7 +37,7 @@ __all__ = [
     "HParamsSpec",
     "get_hparams",
     "from_mlflow",
-    "from_list",
+    "from_auto",
     "from_string",
     "from_file",
 ]

--- a/training/xtime/io.py
+++ b/training/xtime/io.py
@@ -48,7 +48,7 @@ def to_path(path: t.Union[str, Path], check_is_file: bool = False) -> Path:
 
 
 def encode(obj: t.Any) -> t.Any:
-    """General purpose encoder to encode object recursively to JSON serializable format."""
+    """General purpose encoder to encode object recursively to JSON / YAML serializable format."""
     if isinstance(obj, (list, tuple)):
         return [encode(item) for item in obj]
     if isinstance(obj, t.Dict):
@@ -123,18 +123,24 @@ class IO(object):
         return _dict
 
     @staticmethod
-    def save_yaml(data: t.Any, file_path: t.Union[str, Path]) -> None:
+    def save_yaml(data: t.Any, file_path: t.Union[str, Path], raise_on_error: bool = True) -> None:
         try:
             with open(file_path, "w") as stream:
                 yaml.dump(data, stream, Dumper=yaml.SafeDumper)
         except yaml.representer.RepresenterError:
-            logger.warning("file path = %s, data  = %s", file_path, data)
-            raise
+            logger.warning("YAML representation error (file_path=%s, data=%s).", file_path, data)
+            if raise_on_error:
+                raise
 
     @staticmethod
-    def save_json(data: t.Any, file_path: t.Union[str, Path]) -> None:
-        with open(file_path, "w") as stream:
-            json.dump(data, stream)
+    def save_json(data: t.Any, file_path: t.Union[str, Path], raise_on_error: bool = True) -> None:
+        try:
+            with open(file_path, "w") as stream:
+                json.dump(data, stream)
+        except TypeError:
+            logger.warning("JSON representation error (file_path=%s, data=%s).", file_path, data)
+            if raise_on_error:
+                raise
 
     @staticmethod
     def save_data_frame(df: pd.DataFrame, file_path: t.Union[str, Path]) -> None:


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit introduces better support of hyperparameters and fixes several bugs related to them.

1. Hyperparameters specified with Ray Tune can now be serialized in YAML files.
2. Train and HP search commands do not fail now when errors occurred on writing various files (dataset info and run inputs).
3. Unifying access to HP from systems such as hyperparameter recommenders. To get default hyperparameters or their search spaces, or get recommendations, the following format is used: 
    ```
     --params='auto:default:model=xgboost;task=binary_classification;run_type=train' 
    ```
    This example asks `default` recommender to get HPs for XGBoost model solving binary classification problem. Run type is set to `train` instructing to return HP values and not HP search spaces.

# What changes are proposed in this pull request?

- [x] Bug fix.
- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, new and existing unit tests pass locally with my changes.
