### PR TITLE
Introducing XTIME exceptions.

### DIFF
--- a/training/tests/test_errors.py
+++ b/training/tests/test_errors.py
@@ -1,0 +1,38 @@
+###
+# Copyright (2023) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+from unittest import TestCase
+
+from xtime.errors import ConfigurationError, DatasetError, ErrorCode, EstimatorError, XTimeError
+
+
+class TestErrors(TestCase):
+    def test_errors(self) -> None:
+        error = XTimeError("my_custom_error")
+        self.assertEqual(ErrorCode.GENERIC_ERROR, error.error_code)
+
+        error = ConfigurationError("my_custom_error")
+        self.assertEqual(ErrorCode.CONFIGURATION_ERROR, error.error_code)
+
+        error = EstimatorError("my_custom_error")
+        self.assertEqual(ErrorCode.ESTIMATOR_ERROR, error.error_code)
+
+        error = DatasetError("my_custom_error")
+        self.assertEqual(ErrorCode.DATASET_ERROR, error.error_code)
+
+    def test_dataset_errors(self) -> None:
+        error = DatasetError.missing_prerequisites("missing_prerequisites")
+        self.assertIsInstance(error, DatasetError)
+        self.assertEqual(ErrorCode.DATASET_MISSING_PREREQUISITES_ERROR, error.error_code)

--- a/training/xtime/datasets/_churn_modelling.py
+++ b/training/xtime/datasets/_churn_modelling.py
@@ -35,6 +35,8 @@ from .preprocessing import (
 
 __all__ = ["ChurnModellingBuilder"]
 
+from ..errors import DatasetError
+
 
 class ChurnModellingBuilder(DatasetBuilder):
     NAME = "churn_modelling"
@@ -47,7 +49,7 @@ class ChurnModellingBuilder(DatasetBuilder):
 
     def _check_pre_requisites(self) -> None:
         if not (self.path / self.file_name).is_file():
-            raise RuntimeError(
+            raise DatasetError.missing_prerequisites(
                 f"Shrutime (Telco Modelling) not found. Please download it from "
                 f"`https://www.kaggle.com/datasets/shrutimechlearn/churn-modelling` and extract to "
                 f"{self.path.as_posix()}. To proceed, this file must exist: {(self.path / self.file_name).as_posix()}"

--- a/training/xtime/datasets/_ozone_level_detection_one_hour.py
+++ b/training/xtime/datasets/_ozone_level_detection_one_hour.py
@@ -9,6 +9,7 @@ from sklearn.preprocessing import LabelEncoder
 
 from xtime.datasets import Dataset, DatasetBuilder, DatasetMetadata, DatasetSplit
 from xtime.datasets.preprocessing import TimeSeriesEncoderV1
+from xtime.errors import DatasetError
 from xtime.ml import ClassificationTask, Feature, FeatureType, TaskType
 
 __all__ = ["OLD1HRBuilder"]
@@ -46,7 +47,7 @@ class OLD1HRBuilder(DatasetBuilder):
     def _check_pre_requisites(self) -> None:
         # Check raw dataset exists.
         if _XTIME_DATASETS_OLD1HR not in os.environ:
-            raise RuntimeError(
+            raise DatasetError.missing_prerequisites(
                 f"No environment variable found (`{_XTIME_DATASETS_OLD1HR}`) that should point to a directory with "
                 f"OLD1HR (Ozone Level Detection) dataset (`{_OLD1HR_DATASET_FILE}`) that can be downloaded "
                 f"from `{_OLD1HR_HOME_PAGE}`."
@@ -55,7 +56,7 @@ class OLD1HRBuilder(DatasetBuilder):
         if self._dataset_dir.is_file():
             self._dataset_dir = self._dataset_dir.parent
         if not (self._dataset_dir / _OLD1HR_DATASET_FILE).is_file():
-            raise RuntimeError(
+            raise DatasetError.missing_prerequisites(
                 f"OLD1HR dataset location was identified as `{self._dataset_dir}`, but this is either not a directory "
                 f"or dataset file (`{_OLD1HR_DATASET_FILE}`) not found in this location. Please, "
                 f"download (`{_OLD1HR_DATASET_FILE}`) of this "
@@ -67,7 +68,7 @@ class OLD1HRBuilder(DatasetBuilder):
             import tsfresh.feature_extraction.feature_calculators as ts_features
 
         except ImportError:
-            raise RuntimeError(
+            raise DatasetError.missing_prerequisites(
                 f"The OLD1HR dataset requires `tsfresh` library to compute ML features. If it has not been installed, "
                 "please install it with `pip install tsfresh==0.20.2`. If it is installed, there may be incompatible "
                 "CUDA runtime found (see if the cause for the import error is "

--- a/training/xtime/datasets/_rossmann_store_sales.py
+++ b/training/xtime/datasets/_rossmann_store_sales.py
@@ -28,6 +28,8 @@ from .preprocessing import ChangeColumnsTypeToCategory, CheckColumnsOrder, DropC
 
 __all__ = ["RossmannStoreSalesBuilder"]
 
+from ..errors import DatasetError
+
 
 class RossmannStoreSalesBuilder(DatasetBuilder):
     NAME = "rossmann_store_sales"
@@ -41,7 +43,7 @@ class RossmannStoreSalesBuilder(DatasetBuilder):
 
     def _check_pre_requisites(self) -> None:
         if not ((self._data_dir / self._train_file).is_file() and (self._data_dir / self._store_file).is_file()):
-            raise RuntimeError(
+            raise DatasetError.missing_prerequisites(
                 f"Rossmann store sales dataset not found. Please download it from "
                 f"`https://www.kaggle.com/competitions/rossmann-store-sales` and extract to "
                 f"{self._data_dir.as_posix()}. Then, uncompress the archive and compress individual files with gzip "

--- a/training/xtime/datasets/_telco_customer_churn.py
+++ b/training/xtime/datasets/_telco_customer_churn.py
@@ -28,6 +28,8 @@ from .preprocessing import ChangeColumnsTypeToCategory, CheckColumnsOrder
 
 __all__ = ["TelcoCustomerChurnBuilder"]
 
+from ..errors import DatasetError
+
 
 class TelcoCustomerChurnBuilder(DatasetBuilder):
     NAME = "telco_customer_churn"
@@ -40,7 +42,7 @@ class TelcoCustomerChurnBuilder(DatasetBuilder):
 
     def _check_pre_requisites(self) -> None:
         if not (self._data_dir / self._data_file).is_file():
-            raise RuntimeError(
+            raise DatasetError.missing_prerequisites(
                 f"Blastchar (Telco Customer Churn) not found. Please download it from "
                 f"`https://www.kaggle.com/datasets/blastchar/telco-customer-churn` and extract to "
                 f"{self._data_dir.as_posix()}. To proceed, this file "

--- a/training/xtime/errors.py
+++ b/training/xtime/errors.py
@@ -1,0 +1,54 @@
+###
+# Copyright (2023) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+
+class ErrorCode:
+    GENERIC_ERROR = 2
+    CONFIGURATION_ERROR = 50
+    ESTIMATOR_ERROR = 100
+    DATASET_ERROR = 150
+    DATASET_MISSING_PREREQUISITES_ERROR = 151
+
+
+class XTimeError(Exception):
+    def __init__(self, message: str, error_code: int = ErrorCode.GENERIC_ERROR) -> None:
+        super().__init__(message)
+        self._error_code = error_code
+
+    @property
+    def error_code(self) -> int:
+        return self._error_code
+
+
+class ConfigurationError(XTimeError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, error_code=ErrorCode.CONFIGURATION_ERROR)
+
+
+class EstimatorError(XTimeError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, error_code=ErrorCode.ESTIMATOR_ERROR)
+
+
+class DatasetError(XTimeError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, error_code=ErrorCode.DATASET_ERROR)
+
+    @classmethod
+    def missing_prerequisites(cls, message: str) -> "DatasetError":
+        error = DatasetError(message)
+        error._error_code = ErrorCode.DATASET_MISSING_PREREQUISITES_ERROR
+        return error

--- a/training/xtime/main.py
+++ b/training/xtime/main.py
@@ -31,6 +31,7 @@ from xtime.datasets import (
     get_dataset_builder_registry,
     get_known_unknown_datasets,
 )
+from xtime.errors import XTimeError
 from xtime.estimators import get_estimator_registry
 
 logger = logging.getLogger(__name__)
@@ -61,7 +62,7 @@ params_option = click.option(
 )
 
 
-def print_err_and_exit(err: Exception, exit_code: int = 1) -> None:
+def print_err_and_exit(err: Exception) -> None:
     """Print brief information about exception and exit."""
     print(str(err))
     if not logger.root.isEnabledFor(logging.DEBUG):
@@ -69,7 +70,8 @@ def print_err_and_exit(err: Exception, exit_code: int = 1) -> None:
     logger.debug(
         "Error encountered while executing `dataset describe` command.", exc_info=err, stack_info=True, stacklevel=-1
     )
-    exit(exit_code)
+    error_code: int = err.error_code if isinstance(err, XTimeError) else 1
+    exit(error_code)
 
 
 def _run_search_hp_pipeline(


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit adds hierarchy of XTime exceptions (errors). Original motivation is to fix unit tests that fail when a dataset is not present in a system where unit tests run. Concretely, the following changes are introduced:
- Hierarchy of XTime exceptions (`XTimeError`, `ConfigurationError`, `EstimatorError` and `DatasetError`). Each error instance provides an error code that is used to exit the application.
- The `_check_pre_requisites` methods of all supported datasets are update to raise DatasetError exceptions with error code set to `ErrorCode.DATASET_MISSING_PREREQUISITES_ERROR` (151).
- The `print_err_and_exit` function has been refactored. The error code parameter was removed. This function now detects if the error type is XTimeError in which case its error code is used. Else, value of 1 is used.
- Test CLI (`test_dataset_describe`) now does not fail when a particular dataset cannot be created (prerequisited not met).

# What changes are proposed in this pull request?

- [x] Bug fix.
- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, new and existing unit tests pass locally with my changes.
