### PR TITLE
Fixing OZON dataset (label in feature list)

### DIFF
--- a/training/xtime/datasets/_ozone_level_detection_one_hour.py
+++ b/training/xtime/datasets/_ozone_level_detection_one_hour.py
@@ -88,13 +88,18 @@ class OLD1HRBuilder(DatasetBuilder):
         train_df = pd.read_csv(self._dataset_dir / (_OLD1HR_DATASET_FILE + "-default-train.csv"))
         test_df = pd.read_csv(self._dataset_dir / (_OLD1HR_DATASET_FILE + "-default-test.csv"))
 
+        label: str = "label"
+
         # feature_names = self.encoder.features()
         # All features in this dataset are continuous (float64) except first column (Date) which we are dropping
         features = [
-            Feature(col, FeatureType.CONTINUOUS, cardinality=int(train_df[col].nunique())) for col in train_df.columns
+            Feature(col, FeatureType.CONTINUOUS, cardinality=int(train_df[col].nunique()))
+            for col in train_df.columns
+            if col != label
         ]
-
-        label: str = "label"
+        assert (
+            len(features) == len(train_df.columns) - 1
+        ), f"Internal error - wrong number of features (actual={len(features)}, expected={len(train_df.columns) - 1})"
 
         # Encode labels (that are strings here) into numerical representation (0, num_classes-1).
         label_encoder = LabelEncoder().fit(train_df[label])


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Removing column label from the list of features in dataset metadata (`ozone_level_detection_1hr` dataset).

# What changes are proposed in this pull request?

- [x] Bug fix.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] If applicable, new and existing unit tests pass locally with my changes.
