### PR TITLE
Unifying names of estimator unit tests.

### DIFF
--- a/training/tests/estimators/test_catboost.py
+++ b/training/tests/estimators/test_catboost.py
@@ -26,7 +26,7 @@ from xtime.estimators.estimator import unit_test_check_metrics, unit_test_train_
 pytestmark = pytest.mark.estimators
 
 
-class TestXGBoost(TestCase):
+class TestCatboostEstimator(TestCase):
     @with_temp_work_dir
     def test_churn_modelling_numerical(self) -> None:
         ds: Dataset = build_dataset("churn_modelling:numerical")

--- a/training/tests/estimators/test_lightgbm.py
+++ b/training/tests/estimators/test_lightgbm.py
@@ -26,7 +26,7 @@ from xtime.estimators.estimator import unit_test_check_metrics, unit_test_train_
 pytestmark = pytest.mark.estimators
 
 
-class TestXGBoost(TestCase):
+class TestLightGBMEstimator(TestCase):
     @with_temp_work_dir
     def test_churn_modelling_numerical(self) -> None:
         ds: Dataset = build_dataset("churn_modelling:numerical")

--- a/training/tests/estimators/test_xgboost.py
+++ b/training/tests/estimators/test_xgboost.py
@@ -26,7 +26,7 @@ from xtime.estimators.estimator import unit_test_check_metrics, unit_test_train_
 pytestmark = pytest.mark.estimators
 
 
-class TestXGBoost(TestCase):
+class TestXGBoostEstimator(TestCase):
     @with_temp_work_dir
     def test_churn_modelling_numerical(self) -> None:
         ds: Dataset = build_dataset("churn_modelling:numerical")


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit unifies names of unittests for estimators (`TestLightGBMEstimator`, `TestCatboostEstimator`, `TestXGBoostEstimator`). It also fixes a bug where unit tests for `LightGBM` and `Catboost` were named `TestXGBoost`.

# What changes are proposed in this pull request?

- [x] Bug fix.


# Checklist:

- [x] If applicable, new and existing unit tests pass locally with my changes.

