### PR TITLE
Fixing XGBoost warning related to use of `early_stopping_rounds` parameter.

### DIFF
--- a/training/xtime/estimators/_xgboost.py
+++ b/training/xtime/estimators/_xgboost.py
@@ -80,10 +80,12 @@ class XGBoostEstimator(Estimator):
         # clf.best_ntree_limit + early_stopping_rounds (predict will use best_ntree_limit to use the best model).
         # The `clf.best_iteration` will point to the best iteration (clf.best_ntree_limit - 1).
         kwargs = copy.deepcopy(kwargs)
-        if "early_stopping_rounds" not in kwargs:
+        if kwargs.get("early_stopping_rounds", None) is None:
             kwargs["early_stopping_rounds"] = 15
             if "n_estimators" in self.params:
                 kwargs["early_stopping_rounds"] = max(15, int(0.1 * self.params["n_estimators"]))
+        # This parameter is deprecated in `fit` method, so we set it via `set_params`.
+        self.model.set_params(early_stopping_rounds=kwargs.pop("early_stopping_rounds"))
 
         train_split = dataset.split(DatasetSplit.TRAIN)
         eval_split = dataset.split(DatasetSplit.EVAL_SPLITS)


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Removing `early_stopping_rounds` parameter from the `fit` method and moving it to `set_params` as recommended by XGBoost library.

# What changes are proposed in this pull request?

- [x] Bug fix.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] If applicable, new and existing unit tests pass locally with my changes.

