### PR TITLE
Support for external datasets.

### DIFF
--- a/training/tests/datasets/test_dataset.py
+++ b/training/tests/datasets/test_dataset.py
@@ -13,17 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
+import typing as t
 from pathlib import Path
 from unittest import TestCase
 
 from xtime.contrib.unittest_ext import with_temp_work_dir
-from xtime.datasets.dataset import Dataset, DatasetBuilder, DatasetMetadata, DatasetSplit, build_dataset
+from xtime.datasets.dataset import (
+    Dataset,
+    DatasetBuilder,
+    DatasetFactory,
+    DatasetMetadata,
+    DatasetSplit,
+    RegisteredDatasetFactory,
+    SerializedDatasetFactory,
+)
 
 
 class TestDataset(TestCase):
     @with_temp_work_dir
     def test_save_load(self) -> None:
-        ds: Dataset = build_dataset("churn_modelling:default")
+        ds: Dataset = Dataset.create("churn_modelling:default")
         self.assertEqual(ds.metadata.name, "churn_modelling")
         self.assertEqual(ds.metadata.version, "default")
 
@@ -34,3 +43,21 @@ class TestDataset(TestCase):
         self.assertEqual(sorted(list(ds.splits.keys())), sorted(list(loaded_ds.splits.keys())))
 
         # TODO: add unit tests for features and targets
+
+    def test_registered_dataset_factory(self) -> None:
+        # Get all registered datasets
+        dataset_names: t.List[str] = []
+        for dataset_name in RegisteredDatasetFactory.registry.keys():
+            for dataset_version in RegisteredDatasetFactory.registry.get(dataset_name)().builders.keys():
+                dataset_names.append(f"{dataset_name}:{dataset_version}")
+        #
+        self.assertTrue(len(dataset_names) > 0, "No registered datasets found.")
+        #
+        for dataset_name in dataset_names:
+            factories: t.List[DatasetFactory] = DatasetFactory.resolve_factories(dataset_name)
+            self.assertEqual(1, len(factories), f"Expected one factory for '{dataset_name}' dataset.")
+            self.assertIsInstance(
+                factories[0],
+                RegisteredDatasetFactory,
+                f"Expected 'RegisteredDatasetFactory' class for '{dataset_name}' dataset.",
+            )

--- a/training/tests/estimators/test_catboost.py
+++ b/training/tests/estimators/test_catboost.py
@@ -19,7 +19,7 @@ from unittest import TestCase
 import pytest
 
 from xtime.contrib.unittest_ext import with_temp_work_dir
-from xtime.datasets import Dataset, build_dataset
+from xtime.datasets import Dataset
 from xtime.estimators._catboost import CatboostEstimator
 from xtime.estimators.estimator import unit_test_check_metrics, unit_test_train_model
 
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.estimators
 class TestCatboostEstimator(TestCase):
     @with_temp_work_dir
     def test_churn_modelling_numerical(self) -> None:
-        ds: Dataset = build_dataset("churn_modelling:numerical")
+        ds: Dataset = Dataset.create("churn_modelling:numerical")
         self.assertIsInstance(ds, Dataset)
 
         metrics: t.Dict = unit_test_train_model(self, "catboost", CatboostEstimator, ds)
@@ -37,7 +37,7 @@ class TestCatboostEstimator(TestCase):
 
     @with_temp_work_dir
     def test_year_prediction_msd_default(self) -> None:
-        ds: Dataset = build_dataset("year_prediction_msd:default")
+        ds: Dataset = Dataset.create("year_prediction_msd:default")
         self.assertIsInstance(ds, Dataset)
 
         metrics: t.Dict = unit_test_train_model(self, "catboost", CatboostEstimator, ds)

--- a/training/tests/estimators/test_lightgbm.py
+++ b/training/tests/estimators/test_lightgbm.py
@@ -19,7 +19,7 @@ from unittest import TestCase
 import pytest
 
 from xtime.contrib.unittest_ext import with_temp_work_dir
-from xtime.datasets import Dataset, build_dataset
+from xtime.datasets import Dataset
 from xtime.estimators._lightgbm import LightGBMClassifierEstimator
 from xtime.estimators.estimator import unit_test_check_metrics, unit_test_train_model
 
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.estimators
 class TestLightGBMEstimator(TestCase):
     @with_temp_work_dir
     def test_churn_modelling_numerical(self) -> None:
-        ds: Dataset = build_dataset("churn_modelling:numerical")
+        ds: Dataset = Dataset.create("churn_modelling:numerical")
         self.assertIsInstance(ds, Dataset)
 
         metrics: t.Dict = unit_test_train_model(self, "lightgbm", LightGBMClassifierEstimator, ds)
@@ -37,7 +37,7 @@ class TestLightGBMEstimator(TestCase):
 
     @with_temp_work_dir
     def test_year_prediction_msd_default(self) -> None:
-        ds: Dataset = build_dataset("year_prediction_msd:default")
+        ds: Dataset = Dataset.create("year_prediction_msd:default")
         self.assertIsInstance(ds, Dataset)
 
         metrics: t.Dict = unit_test_train_model(self, "lightgbm", LightGBMClassifierEstimator, ds)

--- a/training/tests/estimators/test_xgboost.py
+++ b/training/tests/estimators/test_xgboost.py
@@ -19,7 +19,7 @@ from unittest import TestCase
 import pytest
 
 from xtime.contrib.unittest_ext import with_temp_work_dir
-from xtime.datasets import Dataset, build_dataset
+from xtime.datasets import Dataset
 from xtime.estimators._xgboost import XGBoostEstimator
 from xtime.estimators.estimator import unit_test_check_metrics, unit_test_train_model
 
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.estimators
 class TestXGBoostEstimator(TestCase):
     @with_temp_work_dir
     def test_churn_modelling_numerical(self) -> None:
-        ds: Dataset = build_dataset("churn_modelling:numerical")
+        ds: Dataset = Dataset.create("churn_modelling:numerical")
         self.assertIsInstance(ds, Dataset)
 
         metrics: t.Dict = unit_test_train_model(self, "xgboost", XGBoostEstimator, ds)
@@ -37,7 +37,7 @@ class TestXGBoostEstimator(TestCase):
 
     @with_temp_work_dir
     def test_year_prediction_msd_default(self) -> None:
-        ds: Dataset = build_dataset("year_prediction_msd:default")
+        ds: Dataset = Dataset.create("year_prediction_msd:default")
         self.assertIsInstance(ds, Dataset)
 
         metrics: t.Dict = unit_test_train_model(self, "xgboost", XGBoostEstimator, ds)

--- a/training/tests/test_cli.py
+++ b/training/tests/test_cli.py
@@ -22,7 +22,7 @@ import pytest
 from click import BaseCommand
 from click.testing import CliRunner, Result
 
-from xtime.datasets import DatasetBuilder, get_dataset_builder_registry
+from xtime.datasets import DatasetBuilder, RegisteredDatasetFactory
 from xtime.errors import ErrorCode
 from xtime.main import (
     _run_search_hp_pipeline,
@@ -73,8 +73,9 @@ class TestMain(TestCase):
     def test_dataset_describe(self) -> None:
         """python -m unittest tests.test_cli.TestMain.test_dataset_describe"""
         self.assertIsInstance(dataset_describe, BaseCommand)
-        for name in get_dataset_builder_registry().keys():
-            dataset_builder: DatasetBuilder = get_dataset_builder_registry().get(name)()
+        registry = RegisteredDatasetFactory.registry
+        for name in registry.keys():
+            dataset_builder: DatasetBuilder = registry.get(name)()
             for version in dataset_builder.builders.keys():
                 result: Result = CliRunner().invoke(dataset_describe, [f"{name}:{version}"])
                 if result.exit_code == ErrorCode.DATASET_MISSING_PREREQUISITES_ERROR:

--- a/training/tests/test_registry.py
+++ b/training/tests/test_registry.py
@@ -17,7 +17,7 @@
 import typing as t
 from unittest import TestCase
 
-from xtime.datasets import DatasetBuilder, get_dataset_builder_registry
+from xtime.datasets import DatasetBuilder, RegisteredDatasetFactory
 from xtime.estimators import Estimator, get_estimator_registry
 
 
@@ -37,7 +37,7 @@ class TestRegistry(TestCase):
         self.check_registry(model_registry, expected, Estimator)
 
     def test_dataset_registry(self):
-        dataset_registry = get_dataset_builder_registry()
+        dataset_registry = RegisteredDatasetFactory.registry
         names = dataset_registry.keys()
 
         expected = [

--- a/training/xtime/contrib/mlflow_ext.py
+++ b/training/xtime/contrib/mlflow_ext.py
@@ -25,7 +25,7 @@ from mlflow.store.entities import PagedList
 from mlflow.utils.file_utils import local_file_uri_to_path
 
 from xtime import hparams
-from xtime.datasets import parse_dataset_name
+from xtime.datasets import Dataset
 from xtime.ml import Task
 from xtime.run import RunType
 
@@ -46,7 +46,7 @@ class MLflow(object):
             kwargs: dictionary of additional tags to set.
         """
         if dataset:
-            dataset_name, dataset_version = parse_dataset_name(dataset)
+            dataset_name, dataset_version = Dataset.parse_name(dataset)
             mlflow.set_tags({"dataset_name": dataset_name, "dataset_version": dataset_version})
         if run_type:
             mlflow.set_tag("run_type", run_type.value)
@@ -186,9 +186,18 @@ class MLflow(object):
         """
         # Some metrics produced by Ray Tune we are not interested in.
         _metrics_to_ignore = {
-            "timesteps_total", "time_this_iter_s", "timesteps_total", "episodes_total", "training_iteration",
-            "timestamp", "time_total_s", "pid", "time_since_restore", "timesteps_since_restore",
-            "iterations_since_restore", "warmup_time"
+            "timesteps_total",
+            "time_this_iter_s",
+            "timesteps_total",
+            "episodes_total",
+            "training_iteration",
+            "timestamp",
+            "time_total_s",
+            "pid",
+            "time_since_restore",
+            "timesteps_since_restore",
+            "iterations_since_restore",
+            "warmup_time",
         }
         for name, value in metrics.items():
             try:

--- a/training/xtime/datasets/__init__.py
+++ b/training/xtime/datasets/__init__.py
@@ -17,23 +17,21 @@
 from .dataset import (
     Dataset,
     DatasetBuilder,
+    DatasetFactory,
     DatasetMetadata,
     DatasetSplit,
     DatasetTestCase,
-    build_dataset,
-    get_dataset_builder_registry,
-    get_known_unknown_datasets,
-    parse_dataset_name,
+    RegisteredDatasetFactory,
+    SerializedDatasetFactory,
 )
 
 __all__ = [
     "DatasetSplit",
     "DatasetMetadata",
     "Dataset",
-    "parse_dataset_name",
-    "build_dataset",
-    "get_known_unknown_datasets",
-    "get_dataset_builder_registry",
     "DatasetBuilder",
+    "DatasetFactory",
+    "SerializedDatasetFactory",
+    "RegisteredDatasetFactory",
     "DatasetTestCase",
 ]

--- a/training/xtime/datasets/dataset.py
+++ b/training/xtime/datasets/dataset.py
@@ -31,14 +31,13 @@ from xtime.ml import ClassificationTask, Feature, FeatureType, RegressionTask, T
 from xtime.registry import ClassRegistry
 
 __all__ = [
-    "DatasetSplit",
-    "DatasetMetadata",
-    "Dataset",
-    "parse_dataset_name",
-    "build_dataset",
-    "get_known_unknown_datasets",
-    "get_dataset_builder_registry",
-    "DatasetBuilder",
+    "DatasetSplit",  # Train, test, valid or any other splits without metadata attached.
+    "DatasetMetadata",  # Metadata about concrete dataset.
+    "Dataset",  # Combines metadata with multiple splits into one structure.
+    "DatasetBuilder",  # Class that builds one or multiple versions of a particular dataset.
+    "DatasetFactory",  # Abstract dataset factory.
+    "SerializedDatasetFactory",  # Factory creates datasets that were previously serialized on disk.
+    "RegisteredDatasetFactory",  # Factory creates datasets that are implemented in child classes of `DatasetBuilder`.
     "DatasetTestCase",
 ]
 
@@ -216,6 +215,27 @@ class Dataset:
                 ds.splits[split_name] = DatasetSplit(x=data["x"], y=data["y"])
         return ds
 
+    @staticmethod
+    def create(dataset: str, **kwargs) -> "Dataset":
+        factories: t.List[DatasetFactory] = DatasetFactory.resolve_factories(dataset)
+        registered_datasets = sorted(RegisteredDatasetFactory.registry.keys())
+        if not factories:
+            raise ValueError(
+                f"Dataset (dataset={dataset}) not found in the registry of datasets and not resolved as a serialized "
+                f"dataset. Available datasets in registry: {registered_datasets}."
+            )
+        if len(factories) > 1:
+            sources: str = ". ".join(factory.describe() for factory in factories)
+            raise ValueError(f"The dataset (name='{dataset}') can be loaded from multiple locations. {sources}.")
+        return factories[0].create(**kwargs)
+
+    @staticmethod
+    def parse_name(name: str) -> t.Tuple[t.Optional[str], t.Optional[str]]:
+        name = name.strip()
+        if not name:
+            return None, None
+        return (name, None) if ":" not in name else name.split(":", maxsplit=1)
+
 
 class DatasetBuilder(object):
     NAME: t.Optional[str] = None
@@ -300,40 +320,82 @@ class DatasetBuilder(object):
         return dataset
 
 
-_registry = ClassRegistry(base_cls="xtime.datasets.DatasetBuilder", path=Path(__file__).parent, module="xtime.datasets")
+class DatasetFactory(abc.ABC):
 
+    def __init__(self) -> None: ...
 
-def get_dataset_builder_registry() -> ClassRegistry:
-    return _registry
+    def describe(self) -> str:
+        return ""
 
+    @abc.abstractmethod
+    def create(self, **kwargs) -> Dataset:
+        raise NotImplementedError
 
-def parse_dataset_name(name: str) -> t.Tuple[str, t.Optional[str]]:
-    name_and_version = (name, None) if ":" not in name else name.split(":")
-    if len(name_and_version) != 2:
-        raise ValueError(f"Invalid dataset name: {name}.")
-    return name_and_version
-
-
-def build_dataset(name: str, **kwargs) -> Dataset:
-    name, version = parse_dataset_name(name)
-    version = version or "default"
-    if _registry.contains(name) is False:
-        _available_datasets = sorted(_registry.keys())
-        raise ValueError(
-            f"Dataset (name=`{name}`) not found in the registry of datasets. Available datasets: {_available_datasets}."
+    @staticmethod
+    def resolve_factories(dataset: str) -> t.List["DatasetFactory"]:
+        return list(
+            filter(
+                lambda factory: factory is not None,
+                [SerializedDatasetFactory.resolve(dataset), RegisteredDatasetFactory.resolve(dataset)],
+            )
         )
-    return _registry.get(name)().build(version, **kwargs)
 
 
-def get_known_unknown_datasets(fully_qualified_names: t.List[str]) -> t.Tuple[t.List[str], t.List[str]]:
-    known, unknown = [], []
-    for fully_qualified_name in fully_qualified_names:
-        name, version = parse_dataset_name(fully_qualified_name)
-        if not _registry.contains(name) or not _registry.get(name)().version_supported(version or "default"):
-            unknown.append(fully_qualified_name)
-        else:
-            known.append(fully_qualified_name)
-    return known, unknown
+class SerializedDatasetFactory(DatasetFactory):
+    def __init__(self, dir_path: Path) -> None:
+        super().__init__()
+        self.dir_path = dir_path
+
+    def describe(self) -> str:
+        return f"Serialized dataset (path={self.dir_path.as_posix()})."
+
+    def create(self, **kwargs) -> Dataset:
+        return Dataset.load(self.dir_path)
+
+    @classmethod
+    def resolve(cls, dataset: str) -> t.Optional["SerializedDatasetFactory"]:
+        """Try resolving dataset name as a previously serialized dataset.
+
+        Args:
+            dataset: A possible path to a dataset
+        Returns:
+            SerializedDatasetLoader instance if the name maybe pointing to a serialized dataset, None otherwise.
+                It is not guaranteed that dataset path indeed points to a correct dataset.
+        """
+        file_path = Path(dataset)
+        if file_path.is_file() and file_path.name == "metadata.yaml":
+            return SerializedDatasetFactory(file_path.parent.absolute())
+        if file_path.is_dir() and (file_path / "metadata.yaml").is_file():
+            return SerializedDatasetFactory(file_path.absolute())
+        return None
+
+
+class RegisteredDatasetFactory(DatasetFactory):
+
+    registry = ClassRegistry(
+        base_cls="xtime.datasets.DatasetBuilder", path=Path(__file__).parent, module="xtime.datasets"
+    )
+
+    def __init__(self, name: str, version: str) -> None:
+        super().__init__()
+        self.name = name
+        self.version = version
+
+    def describe(self) -> str:
+        return f"Registered dataset (name={self.name}, version={self.version})."
+
+    def create(self, **kwargs) -> Dataset:
+        return self.registry.get(self.name)().build(self.version, **kwargs)
+
+    @classmethod
+    def resolve(cls, dataset: str) -> t.Optional["RegisteredDatasetFactory"]:
+        name, version = Dataset.parse_name(dataset)
+        if not name:
+            return None
+        version = version or "default"
+        if cls.registry.contains(name) and cls.registry.get(name)().version_supported(version):
+            return RegisteredDatasetFactory(name, version)
+        return None
 
 
 class DatasetTestCase(TestCase):
@@ -368,13 +430,13 @@ class DatasetTestCase(TestCase):
                 test_fn(self, ds, params)
 
     def _load_dataset(self, fully_qualified_name: str) -> t.Tuple[t.Any, str, str]:
-        name, version = parse_dataset_name(fully_qualified_name)
-        dataset_builder_cls: t.Type = _registry.get(name)
+        name, version = Dataset.parse_name(fully_qualified_name)
+        dataset_builder_cls: t.Type = RegisteredDatasetFactory.registry.get(name)
         self.assertIs(
             dataset_builder_cls,
             self.CLASS,
             f"fully_qualified_name={fully_qualified_name}, name={name}, version={version}, "
-            f"dataset_builder_cls={dataset_builder_cls}, _registry.keys()={_registry.keys()}",
+            f"dataset_builder_cls={dataset_builder_cls}, _registry.keys()={RegisteredDatasetFactory.registry.keys()}",
         )
         return dataset_builder_cls().build(version), name, version
 

--- a/training/xtime/estimators/estimator.py
+++ b/training/xtime/estimators/estimator.py
@@ -35,7 +35,6 @@ from sklearn.metrics import (
 
 from xtime.contrib.mlflow_ext import MLflow
 from xtime.datasets import Dataset, DatasetMetadata, DatasetSplit
-from xtime.datasets.dataset import build_dataset
 from xtime.io import IO, encode
 from xtime.ml import METRICS, Task
 from xtime.registry import ClassRegistry
@@ -137,7 +136,7 @@ class Estimator(object):
         no_defaults
         """
         if ctx.dataset is None:
-            ctx.dataset = build_dataset(ctx.metadata.dataset)
+            ctx.dataset = Dataset.create(ctx.metadata.dataset)
 
         if ctx.callbacks:
             callback: Callback = ContainerCallback(ctx.callbacks)

--- a/training/xtime/stages/search_hp.py
+++ b/training/xtime/stages/search_hp.py
@@ -34,7 +34,7 @@ import xtime.contrib.tune_ext as ray_tune_extensions
 import xtime.hparams as hp
 from xtime.contrib.mlflow_ext import MLflow
 from xtime.contrib.tune_ext import Analysis, RayTuneDriverToMLflowLoggerCallback
-from xtime.datasets import build_dataset
+from xtime.datasets import Dataset
 from xtime.estimators import Estimator, get_estimator
 from xtime.hparams import HParamsSource, get_hparams
 from xtime.io import IO, encode
@@ -70,7 +70,7 @@ def search_hp(
         artifact_path: Path = MLflow.get_artifact_path(active_run)
         run_id: str = active_run.info.run_id
 
-        ctx = Context(Metadata(dataset=dataset, model=model, run_type=RunType.HPO), dataset=build_dataset(dataset))
+        ctx = Context(Metadata(dataset=dataset, model=model, run_type=RunType.HPO), dataset=Dataset.create(dataset))
         IO.save_yaml(ctx.dataset.metadata.to_json(), artifact_path / "dataset_info.yaml", raise_on_error=False)
         _set_tags(
             dataset=dataset,

--- a/training/xtime/stages/train.py
+++ b/training/xtime/stages/train.py
@@ -22,7 +22,7 @@ import mlflow
 
 import xtime.contrib.tune_ext as ray_tune_extensions
 from xtime.contrib.mlflow_ext import MLflow
-from xtime.datasets import build_dataset
+from xtime.datasets import Dataset
 from xtime.estimators import Estimator, get_estimator
 from xtime.hparams import HParamsSource, get_hparams
 from xtime.io import IO
@@ -47,7 +47,7 @@ def train(dataset: str, model: str, hparams: t.Optional[HParamsSource]) -> None:
             raise_on_error=False,
         )
         context = Context(
-            metadata=Metadata(dataset=dataset, model=model, run_type=RunType.TRAIN), dataset=build_dataset(dataset)
+            metadata=Metadata(dataset=dataset, model=model, run_type=RunType.TRAIN), dataset=Dataset.create(dataset)
         )
         if hparams is None:
             hparams = f"auto:default:model={model};task={context.dataset.metadata.task.type.value};run_type=train"


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit adds support for external datasets. External datasets are serialized instances of the `Dataset` class. CLI interface that accepts dataset names in the form `name:version` can now accept paths to directories storing these serialized datasets.

Several new classes are added to support this feature. Some of existing methids in `datasets` module has been moved to some other places. New classes that support the new feature:
- `DatasetFactory`: base class for all factories that create datasets.
- `SerializedDatasetFactory`: factory that creates serialized datasets.
- `RegisteredDatasetFactory`: factory that creates registerted (standard) datasets.

# What changes are proposed in this pull request?

- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, new and existing unit tests pass locally with my changes.

