### PR TITLE
ClassRegistry to support modules that cannot be imported.

### DIFF
--- a/training/xtime/errors.py
+++ b/training/xtime/errors.py
@@ -13,6 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
+import logging
+import typing as t
+
+__all__ = [
+    "maybe_suggest_debug_level",
+    "ErrorCode",
+    "XTimeError",
+    "ConfigurationError",
+    "EstimatorError",
+    "DatasetError",
+]
+
+
+def maybe_suggest_debug_level(logger: t.Optional[logging.Logger] = None, prefix: str = " ", suffix: str = ".") -> str:
+    if logger is None or not logger.isEnabledFor(logging.DEBUG):
+        return (
+            f"{prefix}Detailed information is logged when logging level is "
+            f"set to `debug` (rerun with --log-level=debug){suffix}"
+        )
+    return ""
+
+
+def exception_if_debug(error: Exception, logger: logging.Logger) -> t.Optional[Exception]:
+    return error if logger.isEnabledFor(logging.DEBUG) else None
 
 
 class ErrorCode:

--- a/training/xtime/main.py
+++ b/training/xtime/main.py
@@ -26,7 +26,8 @@ from ray import tune
 
 from xtime.datasets import Dataset, DatasetBuilder, DatasetFactory, RegisteredDatasetFactory
 from xtime.errors import XTimeError
-from xtime.estimators import get_estimator_registry
+
+# from xtime.estimators import get_estimator_registry
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +41,7 @@ dataset_arg_help = (
 
 
 model_arg = click.argument("model", type=str, metavar="MODEL")
-model_arg_help = f"Available ML models are: {list(get_estimator_registry().keys())}."
+model_arg_help = f"To get list of available ML models, run `models list` command."
 
 
 params_option = click.option(
@@ -288,6 +289,8 @@ def models() -> None: ...
 @models.command("list", help="List all available models.")
 def model_list() -> None:
     try:
+        from xtime.estimators import get_estimator_registry
+
         print("Available models:")
         for name in get_estimator_registry().keys():
             print(f"- {name}")


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit modifies the class registry class so that it does not fail when a module cannot be imported (`ImportError` error). This can be the case when a module's dependencies have not been installed (such as, for instance, `LightGBM` library for the `LightGBMClassifierEstimator` model).

# What changes are proposed in this pull request?

- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] If applicable, new and existing unit tests pass locally with my changes.
