### PR TITLE
Making `openml` extra dependency.

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -18,6 +18,7 @@ Extra dependencies:
 - `xgboost` XGBoost ML library.
 - `lightgbm` LightGBM library.
 - `timeseries` Packages to create ML datasets for time series data. Installs: [`tsfresh`].
+- `openml` Library required by several datasets hosted on OpenML site.
 
 
 

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -10,7 +10,6 @@ packages = [{include = "xtime"}]
 python = "^3.9"
 llvmlite = ">0.34.0"        # Without this, in Windows OS poetry selects 0.34 that does not have pre-built packages.
 scikit-learn = "1.2.2"      # core dependency
-openml = "0.13.1"           # core dependency
 mlflow = "2.2.2"            # core dependency
 ray = { version = "2.3.1", extras = ["tune", "default"] }   # core dependency
 numpy = "1.23.5"            # core dependency
@@ -29,7 +28,8 @@ coloredlogs = "15.0.1"      # command line interface
 #   1. `poetry install --all-extras`  install all extra dependencies.
 #   2. `poetry install --extras xgboost`
 # If no `--all-extras` / `--extras` provided, the respective installed packages will be uninstalled.
-tsfresh = { version = "0.20.2", optional = true }  # Feature extraction for time series data.
+openml = { version = "0.13.1", optional = true }   # Prerequisite dependency for OpenML datasets.
+tsfresh = { version = "0.20.2", optional = true }  # Prerequisite dependency for time series data sets.
 catboost = { version = "1.1.1", optional = true }  # Gradient boosting trees - CatBoost library.
 lightgbm = { version = "3.3.5", optional = true }  # Gradient boosting trees - LightGBM library.
 xgboost = { version = "2.0.3", optional = true }   # Gradient boosting trees - XGBoost library.
@@ -48,6 +48,7 @@ pandasgui = "0.2.14"
 PyQt5 = "5.15.2"               # Fixes "inable to find installation candidates for pyqt5-qt5 (x.x.x)" in Ubuntu
 
 [tool.poetry.extras]
+openml = ["openml"]
 timeseries = ["tsfresh"]
 catboost = ["catboost"]
 lightgbm = ["lightgbm"]

--- a/training/xtime/datasets/_eye_movements.py
+++ b/training/xtime/datasets/_eye_movements.py
@@ -13,15 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-
-from openml.datasets import get_dataset as get_openml_dataset
-from openml.datasets.dataset import OpenMLDataset
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
 
 from xtime.ml import ClassificationTask, Feature, FeatureType, TaskType
 
-from .dataset import Dataset, DatasetBuilder, DatasetMetadata, DatasetSplit
+from .dataset import Dataset, DatasetBuilder, DatasetMetadata, DatasetPrerequisites, DatasetSplit
 from .preprocessing import ChangeColumnsType, ChangeColumnsTypeToCategory, CheckColumnsOrder, DropColumns
 
 __all__ = ["EyeMovementsBuilder"]
@@ -33,6 +30,9 @@ class EyeMovementsBuilder(DatasetBuilder):
     def __init__(self) -> None:
         super().__init__(openml=True)
         self.builders.update(default=self._build_default_dataset, numerical=self._build_numerical_dataset)
+
+    def _check_pre_requisites(self) -> None:
+        DatasetPrerequisites.check_openml(self.NAME, "openml.org/d/1044")
 
     def _build_default_dataset(self) -> Dataset:
         """Create `eye_movements` train/valid/test datasets.
@@ -51,6 +51,9 @@ class EyeMovementsBuilder(DatasetBuilder):
             Input: 26 features
             Task: multi-class classification (Irrelevant / Relevant / Correct)
         """
+        from openml.datasets import get_dataset as get_openml_dataset
+        from openml.datasets.dataset import OpenMLDataset
+
         # Init parameters.
         random_state: int = 0
         validation_size: float = 0.1

--- a/training/xtime/datasets/_gas_concentrations.py
+++ b/training/xtime/datasets/_gas_concentrations.py
@@ -15,14 +15,12 @@
 ###
 
 import pandas as pd
-from openml.datasets import get_dataset as get_openml_dataset
-from openml.datasets.dataset import OpenMLDataset
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
 
 from xtime.ml import ClassificationTask, Feature, FeatureType, TaskType
 
-from .dataset import Dataset, DatasetBuilder, DatasetMetadata, DatasetSplit
+from .dataset import Dataset, DatasetBuilder, DatasetMetadata, DatasetPrerequisites, DatasetSplit
 
 __all__ = ["GasConcentrationsBuilder"]
 
@@ -33,6 +31,9 @@ class GasConcentrationsBuilder(DatasetBuilder):
     def __init__(self) -> None:
         super().__init__(openml=True)
         self.builders.update(default=self._build_default_dataset, numerical=self._build_numerical_dataset)
+
+    def _check_pre_requisites(self) -> None:
+        DatasetPrerequisites.check_openml(self.NAME, "openml.org/d/1477")
 
     def _build_default_dataset(self) -> Dataset:
         """Create `gas-drift-different-concentrations` train/valid/test datasets.
@@ -48,6 +49,9 @@ class GasConcentrationsBuilder(DatasetBuilder):
             Input: 129 features
             Task: multi-class classification - 6 classes.
         """
+        from openml.datasets import get_dataset as get_openml_dataset
+        from openml.datasets.dataset import OpenMLDataset
+
         # Init parameters.
         random_state: int = 0
         validation_size: float = 0.1

--- a/training/xtime/datasets/_gesture_phase.py
+++ b/training/xtime/datasets/_gesture_phase.py
@@ -15,14 +15,12 @@
 ###
 
 import pandas as pd
-from openml.datasets import get_dataset as get_openml_dataset
-from openml.datasets.dataset import OpenMLDataset
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
 
 from xtime.ml import ClassificationTask, Feature, FeatureType, TaskType
 
-from .dataset import Dataset, DatasetBuilder, DatasetMetadata, DatasetSplit
+from .dataset import Dataset, DatasetBuilder, DatasetMetadata, DatasetPrerequisites, DatasetSplit
 
 __all__ = ["GesturePhaseSegmentationBuilder"]
 
@@ -33,6 +31,9 @@ class GesturePhaseSegmentationBuilder(DatasetBuilder):
     def __init__(self) -> None:
         super().__init__(openml=True)
         self.builders.update(default=self._build_default_dataset, numerical=self._build_numerical_dataset)
+
+    def _check_pre_requisites(self) -> None:
+        DatasetPrerequisites.check_openml(self.NAME, "openml.org/d/4538")
 
     def _build_default_dataset(self) -> Dataset:
         """Create `Gesture Phase Segmentation Processed` train/valid/test datasets.
@@ -47,6 +48,9 @@ class GesturePhaseSegmentationBuilder(DatasetBuilder):
             Input: 32 features
             Task: multi-class classification - 5 classes (RestPosition, Preparation, Stroke, Hold, Retraction).
         """
+        from openml.datasets import get_dataset as get_openml_dataset
+        from openml.datasets.dataset import OpenMLDataset
+
         # Init parameters.
         random_state: int = 0
         validation_size: float = 0.1

--- a/training/xtime/datasets/dataset.py
+++ b/training/xtime/datasets/dataset.py
@@ -26,6 +26,7 @@ from unittest import TestCase
 import pandas as pd
 from pandas import CategoricalDtype
 
+from xtime.errors import DatasetError
 from xtime.io import IO
 from xtime.ml import ClassificationTask, Feature, FeatureType, RegressionTask, Task
 from xtime.registry import ClassRegistry
@@ -38,6 +39,7 @@ __all__ = [
     "DatasetFactory",  # Abstract dataset factory.
     "SerializedDatasetFactory",  # Factory creates datasets that were previously serialized on disk.
     "RegisteredDatasetFactory",  # Factory creates datasets that are implemented in child classes of `DatasetBuilder`.
+    "DatasetPrerequisites",  # Standard checks for dataset prerequisites.
     "DatasetTestCase",
 ]
 
@@ -434,6 +436,28 @@ class RegisteredDatasetFactory(DatasetFactory):
         if cls.registry.contains(name) and cls.registry.get(name)().version_supported(version):
             return RegisteredDatasetFactory(name, version)
         return None
+
+
+class DatasetPrerequisites:
+    """Various standard checks for dataset prerequisites."""
+
+    @staticmethod
+    def check_openml(dataset_name: str, openml_url: str) -> None:
+        """Check if the `openml` library is installed.
+
+        Args:
+            dataset_name: Name of a dataset.
+            openml_url: An OpenML dataset URL
+        """
+        try:
+            import openml
+        except ImportError:
+            raise DatasetError.missing_prerequisites(
+                "The `%s` dataset is an OpenML dataset (%s), and the `openml` package needs to be installed. "
+                "This package is an extra dependency of this project belonging to the `openml` group. With poetry, "
+                "install it by running either `poetry install --extras openml` or `poetry install --all-extras` "
+                "commands.".format(dataset_name, openml_url)
+            )
 
 
 class DatasetTestCase(TestCase):


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

XIME depends on `openml` library to download datasets hosted on OpenML site. This dependency is optional now, install it with `--extras openml`. The presence of this library is checked in `_check_pre_requisites` methods. To implement this, a new class is added - DatasetPrerequisites - that will provide standard checks for dataset prerequisites.

# What changes are proposed in this pull request?

- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] If applicable, new and existing unit tests pass locally with my changes.
