### PR TITLE
New extra (meta)  dependencies.

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -17,8 +17,11 @@ Extra dependencies:
 - `catboost` CatBoost ML library.
 - `xgboost` XGBoost ML library.
 - `lightgbm` LightGBM library.
-- `timeseries` Packages to create ML datasets for time series data. Installs: [`tsfresh`].
+- `timeseries` Packages to create ML datasets for time series data.
 - `openml` Library required by several datasets hosted on OpenML site.
+- `datasets`: Install packages to ensure all datasets can be loaded (includes [`openml`, `timeseries`]).
+- `models`: Install packages to ensure all models can be loaded (includes [`catboost`, `xgboost`, `lightgbm`]).
+- `all`: Install all extra packages.
 
 
 

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -50,9 +50,15 @@ PyQt5 = "5.15.2"               # Fixes "inable to find installation candidates f
 [tool.poetry.extras]
 openml = ["openml"]
 timeseries = ["tsfresh"]
+
 catboost = ["catboost"]
 lightgbm = ["lightgbm"]
 xgboost = ["xgboost"]
+
+datasets = ["openml", "tsfresh"]
+models = ["catboost", "lightgbm", "xgboost"]
+
+all = ["openml", "tsfresh", "catboost", "lightgbm", "xgboost"]
 
 [tool.black]
 # python -m black --config pyproject.toml ./xtime ./tests


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Adding new groups of (meta) dependencies that install:

- `datasets`: Install packages to ensure all datasets can be loaded (includes [`openml`, `timeseries`]).
- `models`: Install packages to ensure all models can be loaded (includes [`catboost`, `xgboost`, `lightgbm`]).
- `all`: Install all extra packages.

# What changes are proposed in this pull request?

- [x] New feature.

