### PR TITLE
Fixing typo in project name.

### DIFF
--- a/training/poetry.lock
+++ b/training/poetry.lock
@@ -2379,7 +2379,7 @@ files = [
 name = "liac-arff"
 version = "2.5.0"
 description = "A module for read and write ARFF files in Python."
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
     {file = "liac-arff-2.5.0.tar.gz", hash = "sha256:3220d0af6487c5aa71b47579be7ad1d94f3849ff1e224af3bf05ad49a0b5c4da"},
@@ -2622,7 +2622,7 @@ files = [
 name = "minio"
 version = "7.2.5"
 description = "MinIO Python SDK for Amazon S3 Compatible Cloud Storage"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "minio-7.2.5-py3-none-any.whl", hash = "sha256:ed9176c96d4271cb1022b9ecb8a538b1e55b32ae06add6de16425cab99ef2304"},
@@ -3133,7 +3133,7 @@ files = [
 name = "openml"
 version = "0.13.1"
 description = "Python API for OpenML"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "openml-0.13.1.tar.gz", hash = "sha256:38ce7c32c28293cb1446d22e96e95e0352f7c62a5d88fe58ffdcad0e8c7a945b"},
@@ -3690,7 +3690,7 @@ files = [
 name = "pycryptodome"
 version = "3.20.0"
 description = "Cryptographic library for Python"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
     {file = "pycryptodome-3.20.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:f0e6d631bae3f231d3634f91ae4da7a960f7ff87f2865b2d2b831af1dfb04e9a"},
@@ -5665,7 +5665,7 @@ scikit-learn = ["scikit-learn"]
 name = "xmltodict"
 version = "0.13.0"
 description = "Makes working with XML feel like you are working with JSON"
-optional = false
+optional = true
 python-versions = ">=3.4"
 files = [
     {file = "xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"},
@@ -5791,12 +5791,16 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [extras]
+all = ["catboost", "lightgbm", "openml", "tsfresh", "xgboost"]
 catboost = ["catboost"]
+datasets = ["openml", "tsfresh"]
 lightgbm = ["lightgbm"]
+models = ["catboost", "lightgbm", "xgboost"]
+openml = ["openml"]
 timeseries = ["tsfresh"]
 xgboost = ["xgboost"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3e38fa69949f401f79629feb3913dbba41c96f1eb7cfc057c125075be13c069d"
+content-hash = "5a9ad588111d03310e326018c9d2605f41a84dcd1955ceb62810b7267157098d"

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "extime-training"
+name = "xtime-training"
 version = "0.1.0"
 description = ""
 authors = ["Hewlett Packard Labs"]


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Fixing typo in project name (in `pyproject.toml`): `extime-training` -> `xtime-training`.

# What changes are proposed in this pull request?

- [x] Bug fix.


# Checklist:

- [x] If applicable, new and existing unit tests pass locally with my changes.

