### PR TITLE
Introducing pyre + ruff.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ catboost_info/
 *.pkl
 model.txt
 run_context.yaml
+dist/
+.pyre/
 
 # cycle_accurate folder
 ## autogen.sh

--- a/training/.pyre_configuration
+++ b/training/.pyre_configuration
@@ -1,0 +1,9 @@
+{
+  "site_package_search_strategy": "pep561",
+  "source_directories": [
+    {
+      "import_root": ".",
+      "source": "xtime"
+    }
+  ]
+}

--- a/training/README.md
+++ b/training/README.md
@@ -202,4 +202,20 @@ Other variables specific to some datasets:
   By setting this variable to 1 it is possible to disable this patching (see `xtime.datasets.DatasetBuilder` class for 
   more details). Usage example: `export XTIME_DISABLE_PATCH_MINIO=1`. When this patching is not disabled, the `xtime`
   looks for proxy server using the following ordered list of environment variables: `https_proxy`, `HTTPS_PROXY`, 
-  `http_proxy`, `HTTP_PROXY`. The fist non-empty value will be used. 
+  `http_proxy`, `HTTP_PROXY`. The fist non-empty value will be used.
+
+# Contribution guidelines
+We will be glad to accept new features, machine learning models or datasets, documentation updates and bug fixes. We
+use the following development guidelines:
+1. Fork this project.
+2. Clone your own fork and configure the python environment by installing all dependencies (e.g., `poetry install --all-extras`).
+3. Create and checkout a new branch (e.g., `bugfix/format-msg`, `feature/new-regression-metric` or `docs/readme-update`).
+4. Fix a bug or implement a new feature, add unit tests.
+5. Run `ruff` and `pyre` (fix warnings and/or errors):
+   ```shell
+   ruff format .
+   ruff check --fix .
+   pyre --search-path $(python -c 'import site; print(site.getsitepackages()[0])') check
+   ```
+6. Run unit tests `pytest`. 
+7. Commit you changes, push to your fork and create a pull request.

--- a/training/notebooks/datasets/churn_modelling.ipynb
+++ b/training/notebooks/datasets/churn_modelling.ipynb
@@ -3,190 +3,192 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "from pandasgui import show\n",
-    "from sklearn.preprocessing import LabelEncoder\n",
-    "from sklearn.model_selection import train_test_split\n",
-    "from pathlib import Path"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import pandas as pd\n",
+    "from pandasgui import show\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.preprocessing import LabelEncoder"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
-    "data_dir = Path('~/.cache/kaggle/datasets/shrutime').expanduser()\n",
-    "file_name = 'Churn_Modelling.csv'\n",
+    "data_dir = Path(\"~/.cache/kaggle/datasets/shrutime\").expanduser()\n",
+    "file_name = \"Churn_Modelling.csv\"\n",
     "\n",
     "data_path = data_dir / file_name\n",
     "data: pd.DataFrame = pd.read_csv(data_path.as_posix())"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "data.head()"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "print(data.index, type(data.index), len(data.index))"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
-    "train_index, valid_index = train_test_split(data.index, train_size=0.8, random_state=0, stratify=data['Exited'])\n",
+    "train_index, valid_index = train_test_split(data.index, train_size=0.8, random_state=0, stratify=data[\"Exited\"])\n",
     "\n",
     "print(train_index, type(train_index), len(train_index))\n",
     "print(valid_index, type(valid_index), len(valid_index))"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
-    "data.iloc[train_index][['Exited']]"
-   ],
+    "data.iloc[train_index][[\"Exited\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "# Analyze it with Pandas GUI library\n",
     "show(data)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "is_executing": true
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Drop unique columns\n",
-    "data.drop('RowNumber', axis=1, inplace=True)\n",
-    "data.drop('CustomerId', axis=1, inplace=True)\n",
+    "data.drop(\"RowNumber\", axis=1, inplace=True)\n",
+    "data.drop(\"CustomerId\", axis=1, inplace=True)\n",
     "\n",
     "# Textual fields (second names)\n",
-    "data.drop('Surname', axis=1, inplace=True)\n",
+    "data.drop(\"Surname\", axis=1, inplace=True)\n",
     "\n",
     "# Convert several numerical columns to floating point format\n",
-    "data['CreditScore'] = data['CreditScore'].astype(float)\n",
-    "data['Age'] = data['Age'].astype(float)\n",
-    "data['Tenure'] = data['Tenure'].astype(float)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "data[\"CreditScore\"] = data[\"CreditScore\"].astype(float)\n",
+    "data[\"Age\"] = data[\"Age\"].astype(float)\n",
+    "data[\"Tenure\"] = data[\"Tenure\"].astype(float)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "for feature in ['Geography', 'Gender']:\n",
-    "    _label_encoder = LabelEncoder().fit(data[feature])\n",
-    "    data[feature] = _label_encoder.transform(data[feature])\n",
-    "    print(feature, _label_encoder.classes_)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "for feature in [\"Geography\", \"Gender\"]:\n",
+    "    _label_encoder = LabelEncoder().fit(data[feature])\n",
+    "    data[feature] = _label_encoder.transform(data[feature])\n",
+    "    print(feature, _label_encoder.classes_)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "outputs": [],
-   "source": [
-    "train, valid = train_test_split(data, train_size=0.8, random_state=0, stratify=data['Exited'])"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "train, valid = train_test_split(data, train_size=0.8, random_state=0, stratify=data[\"Exited\"])"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "from xtime.estimators import Estimator\n",
-    "from xtime.ml import TaskType, ClassificationTask\n",
-    "from xtime.datasets import (Dataset, DatasetSplit, DatasetMetadata)\n",
-    "from sklearn.dummy import DummyClassifier\n",
-    "\n",
-    "dataset = Dataset(\n",
-    "    metadata=DatasetMetadata(\n",
-    "        name='Churn_Modelling',\n",
-    "        version='NA',\n",
-    "        task=ClassificationTask(type_=TaskType.BINARY_CLASSIFICATION, num_classes=2)\n",
-    "    ),\n",
-    "    splits={\n",
-    "        'train': DatasetSplit(x=train.drop('Exited', axis=1, inplace=False), y=train['Exited']),\n",
-    "        'valid': DatasetSplit(x=train.drop('Exited', axis=1, inplace=False), y=train['Exited'])\n",
-    "    }\n",
-    ")\n",
-    "\n",
-    "estimator = Estimator()\n",
-    "estimator.model = DummyClassifier(strategy=\"prior\").fit(dataset.splits['train'].x, dataset.splits['train'].y)\n",
-    "\n",
-    "metrics = estimator.evaluate(dataset)\n",
-    "print(metrics)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.dummy import DummyClassifier\n",
+    "\n",
+    "from xtime.datasets import Dataset, DatasetMetadata, DatasetSplit\n",
+    "from xtime.estimators import Estimator\n",
+    "from xtime.ml import ClassificationTask, TaskType\n",
+    "\n",
+    "dataset = Dataset(\n",
+    "    metadata=DatasetMetadata(\n",
+    "        name=\"Churn_Modelling\",\n",
+    "        version=\"NA\",\n",
+    "        task=ClassificationTask(type_=TaskType.BINARY_CLASSIFICATION, num_classes=2),\n",
+    "    ),\n",
+    "    splits={\n",
+    "        \"train\": DatasetSplit(x=train.drop(\"Exited\", axis=1, inplace=False), y=train[\"Exited\"]),\n",
+    "        \"valid\": DatasetSplit(x=train.drop(\"Exited\", axis=1, inplace=False), y=train[\"Exited\"]),\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "estimator = Estimator()\n",
+    "estimator.model = DummyClassifier(strategy=\"prior\").fit(dataset.splits[\"train\"].x, dataset.splits[\"train\"].y)\n",
+    "\n",
+    "metrics = estimator.evaluate(dataset)\n",
+    "print(metrics)"
+   ]
   }
  ],
  "metadata": {

--- a/training/notebooks/datasets/eye_movements.ipynb
+++ b/training/notebooks/datasets/eye_movements.ipynb
@@ -3,142 +3,137 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "from openml.datasets import get_dataset as get_openml_dataset\n",
     "from openml.datasets.dataset import OpenMLDataset\n",
     "from pandasgui import show\n",
     "from sklearn.model_selection import train_test_split"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "data: OpenMLDataset = get_openml_dataset(\n",
-    "    dataset_id=\"eye_movements\",\n",
-    "    version=1,\n",
-    "    error_if_multiple=True,\n",
-    "    download_data=True\n",
-    ")\n",
-    "\n",
-    "# Load from local cache\n",
-    "x, y, categorical_indicator, attributed_names = data.get_data(\n",
-    "    target=data.default_target_attribute,\n",
-    "    dataset_format='dataframe'\n",
-    ")\n",
-    "\n",
-    "print(type(x), type(y))"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "data: OpenMLDataset = get_openml_dataset(\n",
+    "    dataset_id=\"eye_movements\", version=1, error_if_multiple=True, download_data=True\n",
+    ")\n",
+    "\n",
+    "# Load from local cache\n",
+    "x, y, categorical_indicator, attributed_names = data.get_data(\n",
+    "    target=data.default_target_attribute, dataset_format=\"dataframe\"\n",
+    ")\n",
+    "\n",
+    "print(type(x), type(y))"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "# Analyze it with Pandas GUI library\n",
     "show(x)\n",
     "# show(y)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "is_executing": true
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Encode labels. Move from `category` type to int type with labels [0, 1, 2]\n",
     "y = y.astype(int)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Drop unique columns\n",
-    "x.drop('lineNo', axis=1, inplace=True)\n",
+    "x.drop(\"lineNo\", axis=1, inplace=True)\n",
     "\n",
     "# Convert `category` features to int type.\n",
-    "x['P1stFixation'] = x['P1stFixation'].astype(int)  # Binary 0/1\n",
-    "x['P2stFixation'] = x['P2stFixation'].astype(int)  # Binary 0/1\n",
-    "x['nextWordRegress'] = x['nextWordRegress'].astype(int)  # Binary 0/1"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "x[\"P1stFixation\"] = x[\"P1stFixation\"].astype(int)  # Binary 0/1\n",
+    "x[\"P2stFixation\"] = x[\"P2stFixation\"].astype(int)  # Binary 0/1\n",
+    "x[\"nextWordRegress\"] = x[\"nextWordRegress\"].astype(int)  # Binary 0/1"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "test_size = 0.2\n",
     "validation_size = 0.1\n",
     "\n",
-    "train_x, test_x, train_y, test_y = train_test_split(\n",
-    "    x, y, test_size=test_size, random_state=1, shuffle=True\n",
-    ")\n",
+    "train_x, test_x, train_y, test_y = train_test_split(x, y, test_size=test_size, random_state=1, shuffle=True)\n",
     "train_x, valid_x, train_y, valid_y = train_test_split(\n",
     "    train_x, train_y, test_size=validation_size / (1.0 - test_size), random_state=1, shuffle=True\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "from xtime.estimators import Estimator\n",
-    "from xtime.ml import TaskType, ClassificationTask\n",
-    "from xtime.datasets import (Dataset, DatasetSplit, DatasetMetadata)\n",
-    "from sklearn.dummy import DummyClassifier\n",
-    "\n",
-    "dataset = Dataset(\n",
-    "    metadata=DatasetMetadata(\n",
-    "        name='eye_movements',\n",
-    "        version='NA',\n",
-    "        task=ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=3)\n",
-    "    ),\n",
-    "    splits={\n",
-    "        'train': DatasetSplit(x=train_x, y=train_y),\n",
-    "        'valid': DatasetSplit(x=valid_x, y=valid_y),\n",
-    "        'test': DatasetSplit(x=test_x, y=test_y)\n",
-    "    }\n",
-    ")\n",
-    "estimator = Estimator()\n",
-    "estimator.model = DummyClassifier(strategy=\"prior\").fit(dataset.splits['train'].x, dataset.splits['train'].y)\n",
-    "\n",
-    "metrics = estimator.evaluate(dataset)\n",
-    "print(metrics)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.dummy import DummyClassifier\n",
+    "\n",
+    "from xtime.datasets import Dataset, DatasetMetadata, DatasetSplit\n",
+    "from xtime.estimators import Estimator\n",
+    "from xtime.ml import ClassificationTask, TaskType\n",
+    "\n",
+    "dataset = Dataset(\n",
+    "    metadata=DatasetMetadata(\n",
+    "        name=\"eye_movements\",\n",
+    "        version=\"NA\",\n",
+    "        task=ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=3),\n",
+    "    ),\n",
+    "    splits={\n",
+    "        \"train\": DatasetSplit(x=train_x, y=train_y),\n",
+    "        \"valid\": DatasetSplit(x=valid_x, y=valid_y),\n",
+    "        \"test\": DatasetSplit(x=test_x, y=test_y),\n",
+    "    },\n",
+    ")\n",
+    "estimator = Estimator()\n",
+    "estimator.model = DummyClassifier(strategy=\"prior\").fit(dataset.splits[\"train\"].x, dataset.splits[\"train\"].y)\n",
+    "\n",
+    "metrics = estimator.evaluate(dataset)\n",
+    "print(metrics)"
+   ]
   }
  ],
  "metadata": {

--- a/training/notebooks/datasets/forest_cover_type.ipynb
+++ b/training/notebooks/datasets/forest_cover_type.ipynb
@@ -3,115 +3,117 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
     "from pandasgui import show\n",
     "from sklearn import datasets\n",
-    "from sklearn.utils import Bunch\n",
+    "from sklearn.model_selection import train_test_split\n",
     "from sklearn.preprocessing import LabelEncoder\n",
-    "from sklearn.model_selection import train_test_split"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "from sklearn.utils import Bunch"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "bunch: Bunch = datasets.fetch_covtype(download_if_missing=True)\n",
     "data = pd.DataFrame(\n",
-    "    np.hstack([bunch.data, bunch.target.reshape((-1, 1))]),\n",
-    "    columns=bunch.feature_names + bunch.target_names\n",
+    "    np.hstack([bunch.data, bunch.target.reshape((-1, 1))]), columns=bunch.feature_names + bunch.target_names\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "show(data)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "show(data)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "features = []\n",
-    "label: str = 'Cover_Type'\n",
+    "label: str = \"Cover_Type\"\n",
     "for feature in data.columns:\n",
-    "    if feature.startswith('Wilderness_Area') or feature.startswith('Soil_Type'):\n",
+    "    if feature.startswith(\"Wilderness_Area\") or feature.startswith(\"Soil_Type\"):\n",
     "        data[feature] = data[feature].astype(int)\n",
     "    elif feature == label:\n",
     "        data[feature] = LabelEncoder().fit_transform(data[feature].astype(int))\n",
     "    else:\n",
     "        ..."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "_orig_size = len(data)\n",
-    "data.dropna(axis=0, how='any', inplace=True)\n",
+    "data.dropna(axis=0, how=\"any\", inplace=True)\n",
     "print(f\"DropNA: {_orig_size - len(data)} instances have been removed.\")"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "bunch.feature_names"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "is_executing": true
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "bunch.target_names"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "bunch.target_names"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# https://github.com/RAMitchell/GBM-Benchmarks/blob/a0bbed08c918b0a82e9a5e2207d1f43134b445e0/benchmark.py#L150\n",
@@ -120,46 +122,44 @@
     "\n",
     "train, test = train_test_split(data, test_size=test_size, random_state=0)\n",
     "train, valid = train_test_split(train, test_size=validation_size / (1.0 - test_size), random_state=0)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "from xtime.estimators import Estimator\n",
-    "from xtime.ml import TaskType, ClassificationTask\n",
-    "from xtime.datasets import (Dataset, DatasetSplit, DatasetMetadata)\n",
-    "from sklearn.dummy import DummyClassifier\n",
-    "\n",
-    "dataset = Dataset(\n",
-    "    metadata=DatasetMetadata(\n",
-    "        name='Forest_Cover_Type',\n",
-    "        version='NA',\n",
-    "        task=ClassificationTask(type_=TaskType.BINARY_CLASSIFICATION, num_classes=2),\n",
-    "    ),\n",
-    "    splits={\n",
-    "        'train': DatasetSplit(x=train.drop(label, axis=1, inplace=False), y=train[label]),\n",
-    "        'valid': DatasetSplit(x=train.drop(label, axis=1, inplace=False), y=train[label]),\n",
-    "        'test': DatasetSplit(x=test.drop(label, axis=1, inplace=False), y=test[label])\n",
-    "    }\n",
-    ")\n",
-    "\n",
-    "estimator = Estimator()\n",
-    "estimator.model = DummyClassifier(strategy=\"prior\").fit(dataset.splits['train'].x, dataset.splits['train'].y)\n",
-    "\n",
-    "metrics = estimator.evaluate(dataset)\n",
-    "print(metrics)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.dummy import DummyClassifier\n",
+    "\n",
+    "from xtime.datasets import Dataset, DatasetMetadata, DatasetSplit\n",
+    "from xtime.estimators import Estimator\n",
+    "from xtime.ml import ClassificationTask, TaskType\n",
+    "\n",
+    "dataset = Dataset(\n",
+    "    metadata=DatasetMetadata(\n",
+    "        name=\"Forest_Cover_Type\",\n",
+    "        version=\"NA\",\n",
+    "        task=ClassificationTask(type_=TaskType.BINARY_CLASSIFICATION, num_classes=2),\n",
+    "    ),\n",
+    "    splits={\n",
+    "        \"train\": DatasetSplit(x=train.drop(label, axis=1, inplace=False), y=train[label]),\n",
+    "        \"valid\": DatasetSplit(x=train.drop(label, axis=1, inplace=False), y=train[label]),\n",
+    "        \"test\": DatasetSplit(x=test.drop(label, axis=1, inplace=False), y=test[label]),\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "estimator = Estimator()\n",
+    "estimator.model = DummyClassifier(strategy=\"prior\").fit(dataset.splits[\"train\"].x, dataset.splits[\"train\"].y)\n",
+    "\n",
+    "metrics = estimator.evaluate(dataset)\n",
+    "print(metrics)"
+   ]
   }
  ],
  "metadata": {

--- a/training/notebooks/datasets/gas_concentrations.ipynb
+++ b/training/notebooks/datasets/gas_concentrations.ipynb
@@ -3,123 +3,118 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from pandasgui import show\n",
-    "from sklearn.preprocessing import LabelEncoder\n",
-    "from sklearn.model_selection import train_test_split\n",
     "from openml import OpenMLDataset\n",
-    "from openml.datasets import get_dataset as get_openml_dataset"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "from openml.datasets import get_dataset as get_openml_dataset\n",
+    "from pandasgui import show\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.preprocessing import LabelEncoder"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Fetch dataset and its description from OpenML. Will be cached in ${HOME}/.openml\n",
     "data: OpenMLDataset = get_openml_dataset(\n",
-    "    dataset_id=\"gas-drift-different-concentrations\",\n",
-    "    version=1,\n",
-    "    error_if_multiple=True,\n",
-    "    download_data=True\n",
+    "    dataset_id=\"gas-drift-different-concentrations\", version=1, error_if_multiple=True, download_data=True\n",
     ")\n",
     "\n",
     "# Load from local cache\n",
     "x, y, categorical_indicator, attributed_names = data.get_data(\n",
-    "    target=data.default_target_attribute,\n",
-    "    dataset_format='dataframe'\n",
+    "    target=data.default_target_attribute, dataset_format=\"dataframe\"\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "# Analyze it with Pandas GUI library\n",
     "show(x)\n",
     "# show(y)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "is_executing": true
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "y = pd.Series(LabelEncoder().fit_transform(y), index=y.index, name=y.name)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "test_size = 0.2\n",
     "validation_size = 0.1\n",
     "\n",
-    "train_x, test_x, train_y, test_y = train_test_split(\n",
-    "    x, y, test_size=test_size, random_state=1, shuffle=True\n",
-    ")\n",
+    "train_x, test_x, train_y, test_y = train_test_split(x, y, test_size=test_size, random_state=1, shuffle=True)\n",
     "train_x, valid_x, train_y, valid_y = train_test_split(\n",
     "    train_x, train_y, test_size=validation_size / (1.0 - test_size), random_state=1, shuffle=True\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "from xtime.estimators import Estimator\n",
-    "from xtime.ml import TaskType, ClassificationTask\n",
-    "from xtime.datasets import (Dataset, DatasetSplit, DatasetMetadata)\n",
-    "from sklearn.dummy import DummyClassifier\n",
-    "\n",
-    "dataset = Dataset(\n",
-    "    metadata=DatasetMetadata(\n",
-    "        name='gas_concentrations',\n",
-    "        version='NA',\n",
-    "        task=ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=6),\n",
-    "    ),\n",
-    "    splits={\n",
-    "        'train': DatasetSplit(x=train_x, y=train_y),\n",
-    "        'valid': DatasetSplit(x=valid_x, y=valid_y),\n",
-    "        'test': DatasetSplit(x=test_x, y=test_y)\n",
-    "    }\n",
-    ")\n",
-    "\n",
-    "estimator = Estimator()\n",
-    "estimator.model = DummyClassifier(strategy=\"prior\").fit(dataset.splits['train'].x, dataset.splits['train'].y)\n",
-    "\n",
-    "metrics = estimator.evaluate(dataset)\n",
-    "print(metrics)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.dummy import DummyClassifier\n",
+    "\n",
+    "from xtime.datasets import Dataset, DatasetMetadata, DatasetSplit\n",
+    "from xtime.estimators import Estimator\n",
+    "from xtime.ml import ClassificationTask, TaskType\n",
+    "\n",
+    "dataset = Dataset(\n",
+    "    metadata=DatasetMetadata(\n",
+    "        name=\"gas_concentrations\",\n",
+    "        version=\"NA\",\n",
+    "        task=ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=6),\n",
+    "    ),\n",
+    "    splits={\n",
+    "        \"train\": DatasetSplit(x=train_x, y=train_y),\n",
+    "        \"valid\": DatasetSplit(x=valid_x, y=valid_y),\n",
+    "        \"test\": DatasetSplit(x=test_x, y=test_y),\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "estimator = Estimator()\n",
+    "estimator.model = DummyClassifier(strategy=\"prior\").fit(dataset.splits[\"train\"].x, dataset.splits[\"train\"].y)\n",
+    "\n",
+    "metrics = estimator.evaluate(dataset)\n",
+    "print(metrics)"
+   ]
   }
  ],
  "metadata": {

--- a/training/notebooks/datasets/gesture_phase.ipynb
+++ b/training/notebooks/datasets/gesture_phase.ipynb
@@ -3,123 +3,118 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from pandasgui import show\n",
     "from openml import OpenMLDataset\n",
     "from openml.datasets import get_dataset as get_openml_dataset\n",
-    "from sklearn.preprocessing import LabelEncoder\n",
-    "from sklearn.model_selection import train_test_split"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "from pandasgui import show\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.preprocessing import LabelEncoder"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Fetch dataset and its description from OpenML. Will be cached in ${HOME}/.openml\n",
     "data: OpenMLDataset = get_openml_dataset(\n",
-    "    dataset_id=\"GesturePhaseSegmentationProcessed\",\n",
-    "    version=1,\n",
-    "    error_if_multiple=True,\n",
-    "    download_data=True\n",
+    "    dataset_id=\"GesturePhaseSegmentationProcessed\", version=1, error_if_multiple=True, download_data=True\n",
     ")\n",
     "\n",
     "x, y, categorical_indicator, attributed_names = data.get_data(\n",
-    "    target=data.default_target_attribute,\n",
-    "    dataset_format='dataframe'\n",
+    "    target=data.default_target_attribute, dataset_format=\"dataframe\"\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "# Analyze it with Pandas GUI library\n",
-    "show(x)\n",
-    "# show(y)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "# Analyze it with Pandas GUI library\n",
+    "show(x)\n",
+    "# show(y)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "y = pd.Series(LabelEncoder().fit_transform(y), index=y.index, name=y.name)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "test_size = 0.2\n",
     "validation_size = 0.1\n",
     "\n",
     "# Split into train/valid/test according to paper\n",
-    "train_x, test_x, train_y, test_y = train_test_split(\n",
-    "    x, y, test_size=test_size, random_state=1, shuffle=True\n",
-    ")\n",
+    "train_x, test_x, train_y, test_y = train_test_split(x, y, test_size=test_size, random_state=1, shuffle=True)\n",
     "train_x, valid_x, train_y, valid_y = train_test_split(\n",
     "    train_x, train_y, test_size=validation_size / (1.0 - test_size), random_state=1, shuffle=True\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "from xtime.estimators import Estimator\n",
-    "from xtime.ml import TaskType, ClassificationTask\n",
-    "from xtime.datasets import (Dataset, DatasetSplit, DatasetMetadata)\n",
-    "from sklearn.dummy import DummyClassifier\n",
-    "\n",
-    "dataset = Dataset(\n",
-    "    metadata=DatasetMetadata(\n",
-    "        name='gesture_phase',\n",
-    "        version='NA',\n",
-    "        task=ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=5),\n",
-    "    ),\n",
-    "    splits={\n",
-    "        'train': DatasetSplit(x=train_x, y=train_y),\n",
-    "        'valid': DatasetSplit(x=valid_x, y=valid_y),\n",
-    "        'test': DatasetSplit(x=test_x, y=test_y)\n",
-    "    }\n",
-    ")\n",
-    "\n",
-    "estimator = Estimator()\n",
-    "estimator.model = DummyClassifier(strategy=\"prior\").fit(dataset.splits['train'].x, dataset.splits['train'].y)\n",
-    "\n",
-    "metrics = estimator.evaluate(dataset)\n",
-    "print(metrics)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.dummy import DummyClassifier\n",
+    "\n",
+    "from xtime.datasets import Dataset, DatasetMetadata, DatasetSplit\n",
+    "from xtime.estimators import Estimator\n",
+    "from xtime.ml import ClassificationTask, TaskType\n",
+    "\n",
+    "dataset = Dataset(\n",
+    "    metadata=DatasetMetadata(\n",
+    "        name=\"gesture_phase\",\n",
+    "        version=\"NA\",\n",
+    "        task=ClassificationTask(type_=TaskType.MULTI_CLASS_CLASSIFICATION, num_classes=5),\n",
+    "    ),\n",
+    "    splits={\n",
+    "        \"train\": DatasetSplit(x=train_x, y=train_y),\n",
+    "        \"valid\": DatasetSplit(x=valid_x, y=valid_y),\n",
+    "        \"test\": DatasetSplit(x=test_x, y=test_y),\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "estimator = Estimator()\n",
+    "estimator.model = DummyClassifier(strategy=\"prior\").fit(dataset.splits[\"train\"].x, dataset.splits[\"train\"].y)\n",
+    "\n",
+    "metrics = estimator.evaluate(dataset)\n",
+    "print(metrics)"
+   ]
   }
  ],
  "metadata": {

--- a/training/notebooks/datasets/rossmann_store_sales.ipynb
+++ b/training/notebooks/datasets/rossmann_store_sales.ipynb
@@ -2,6 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "## Rossmann Store Sales\n",
     "\n",
@@ -19,50 +22,56 @@
     "2018a.\n",
     "\n",
     "Repository with benchmarks - [rossman-store-sales](https://github.com/catboost/benchmarks/tree/master/kaggle/rossmann-store-sales)."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "import calendar\n",
+    "from pathlib import Path\n",
+    "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "from pandasgui import show\n",
-    "from sklearn.preprocessing import LabelEncoder\n",
-    "from pathlib import Path"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "from sklearn.preprocessing import LabelEncoder"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "def print_nan_statistics(_name: str, _df: pd.DataFrame):\n",
     "    for _column in _df.columns:\n",
     "        _nan_mask = _df[_column].isnull()\n",
     "        if _nan_mask.any():\n",
-    "            print(f\"name={_name}, column={_column}, num_unique_values={len(_df[_column].unique())}, num_nans={_nan_mask.sum()} dtype={_df[_column].dtype}\")"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "            print(\n",
+    "                f\"name={_name}, column={_column}, num_unique_values={len(_df[_column].unique())}, num_nans={_nan_mask.sum()} dtype={_df[_column].dtype}\"\n",
+    "            )"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
-    "data_dir = Path('~/.cache/kaggle/datasets/rossmann_store_sales').expanduser()\n",
-    "store_file = 'store.csv.gz'\n",
-    "train_file = 'train.csv.gz'\n",
+    "data_dir = Path(\"~/.cache/kaggle/datasets/rossmann_store_sales\").expanduser()\n",
+    "store_file = \"store.csv.gz\"\n",
+    "train_file = \"train.csv.gz\"\n",
     "\n",
     "train: pd.DataFrame = pd.read_csv((data_dir / train_file).as_posix())\n",
     "store: pd.DataFrame = pd.read_csv((data_dir / store_file).as_posix())\n",
@@ -71,369 +80,364 @@
     "print(f\"store: shape={store.shape}, columns={list(store.columns)}\")\n",
     "\n",
     "print(train.dtypes)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "is_executing": true
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# https://docs.python.org/3/library/calendar.html#calendar.month_abbr\n",
     "month_abbrs = calendar.month_abbr[1:]\n",
     "# It's `Sep` by default, but dataset uses Sept.\n",
-    "month_abbrs[8] = 'Sept'"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "month_abbrs[8] = \"Sept\""
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# StateHoliday - indicates a state holiday. Normally all stores, with few exceptions, are closed on state holidays.\n",
     "# Note that all schools are closed on public holidays and weekends. a = public holiday, b = Easter holiday, c = Christmas, 0 = None\n",
-    "train['StateHoliday'].replace(0, 'n', inplace=True)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "train[\"StateHoliday\"].replace(0, \"n\", inplace=True)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "# Convert Date column (e.g., 2015-07-31) into three integer columns - year, month and day\n",
-    "train[['Year', 'Month', 'Day']] = train['Date'].str.split('-', 3, expand=True).astype(int)\n",
-    "train.drop(['Date'], axis=1, inplace=True)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "# Convert Date column (e.g., 2015-07-31) into three integer columns - year, month and day\n",
+    "train[[\"Year\", \"Month\", \"Day\"]] = train[\"Date\"].str.split(\"-\", 3, expand=True).astype(int)\n",
+    "train.drop([\"Date\"], axis=1, inplace=True)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
-    "print_nan_statistics('train', train)\n",
-    "print_nan_statistics('store', store)\n",
+    "print_nan_statistics(\"train\", train)\n",
+    "print_nan_statistics(\"store\", store)\n",
     "\n",
     "# Promo2 - Promo2 is a continuing and consecutive promotion for some stores: 0 = store is not participating, 1 = store is participating\n",
     "# Promo2Since[Year/Week] - describes the year and calendar week when the store started participating in Promo2\n",
     "\n",
     "# Promo2SinceWeek and Promo2SinceYear are NaNs when Promo2 is 0 (0 = store is not participating)\n",
     "# Do not care that much about PromoInterval - it will be removed later.\n",
-    "print(store['Promo2'].value_counts().to_dict())"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "is_executing": true
-    }
-   }
+    "print(store[\"Promo2\"].value_counts().to_dict())"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Join with store table\n",
-    "train = train.join(store, on='Store', rsuffix='_right')\n",
-    "train.drop(['Store_right'], axis=1, inplace=True)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "train = train.join(store, on=\"Store\", rsuffix=\"_right\")\n",
+    "train.drop([\"Store_right\"], axis=1, inplace=True)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Convert `PromoInterval` (e.g., Jan,Apr,Jul,Oct) into binary variables\n",
-    "promo2_start_months = [(s.split(',') if not pd.isnull(s) else []) for s in train['PromoInterval']]\n",
+    "promo2_start_months = [(s.split(\",\") if not pd.isnull(s) else []) for s in train[\"PromoInterval\"]]\n",
     "for month_abbr in month_abbrs:\n",
-    "    train['Promo2Start_' + month_abbr] = np.array([(1 if month_abbr in s else 0) for s in promo2_start_months])\n",
-    "train.drop(['PromoInterval'], axis=1, inplace=True)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "    train[\"Promo2Start_\" + month_abbr] = np.array([(1 if month_abbr in s else 0) for s in promo2_start_months])\n",
+    "train.drop([\"PromoInterval\"], axis=1, inplace=True)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "print_nan_statistics('train', train)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "print_nan_statistics(\"train\", train)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "show(train)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "is_executing": true
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# StoreType - differentiates between 4 different store models: a, b, c, d\n",
-    "train['StoreType'].fillna('na', inplace=True)\n",
+    "train[\"StoreType\"].fillna(\"na\", inplace=True)\n",
     "# Assortment - describes an assortment level: a = basic, b = extra, c = extended\n",
-    "train['Assortment'].fillna('na', inplace=True)\n",
+    "train[\"Assortment\"].fillna(\"na\", inplace=True)\n",
     "\n",
     "# CompetitionDistance - distance in meters to the nearest competitor store\n",
-    "train['CompetitionDistance'].fillna(-1, inplace=True)\n",
-    "train['CompetitionOpenSinceMonth'].fillna(0, inplace=True)\n",
-    "train['CompetitionOpenSinceYear'].fillna(0, inplace=True)\n",
+    "train[\"CompetitionDistance\"].fillna(-1, inplace=True)\n",
+    "train[\"CompetitionOpenSinceMonth\"].fillna(0, inplace=True)\n",
+    "train[\"CompetitionOpenSinceYear\"].fillna(0, inplace=True)\n",
     "\n",
     "# Promo2 - Promo2 is a continuing and consecutive promotion for some stores: 0 = store is not participating, 1 = store is participating\n",
-    "train['Promo2'].fillna(0, inplace=True)\n",
-    "train['Promo2SinceWeek'].fillna(-1, inplace=True)\n",
-    "train['Promo2SinceYear'].fillna(-1, inplace=True)\n",
+    "train[\"Promo2\"].fillna(0, inplace=True)\n",
+    "train[\"Promo2SinceWeek\"].fillna(-1, inplace=True)\n",
+    "train[\"Promo2SinceYear\"].fillna(-1, inplace=True)\n",
     "\n",
-    "train['Promo2'] = train['Promo2'].astype(int)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "train[\"Promo2\"] = train[\"Promo2\"].astype(int)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "outputs": [],
-   "source": [
-    "print_nan_statistics('train', train)"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "print_nan_statistics(\"train\", train)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "train.head(n=5)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "train.head(n=5)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "# Split into train/test splits\n",
-    "train_indices = train[train['Year'] == 2014].index\n",
-    "test_indices = train[train['Year'] == 2015].index\n",
+    "train_indices = train[train[\"Year\"] == 2014].index\n",
+    "test_indices = train[train[\"Year\"] == 2015].index\n",
     "\n",
     "train_split = train.iloc[train_indices].reset_index(drop=True)\n",
     "test_split = train.iloc[test_indices].reset_index(drop=True)\n",
     "\n",
     "print(f\"train_split={train_split.shape}, test_split={test_split.shape}\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "is_executing": true
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "show(train_split)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "show(train_split)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "outputs": [],
-   "source": [
-    "m = test_split['Sales'].mean()"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "m = test_split[\"Sales\"].mean()"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "515.450 / m"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "is_executing": true
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "643.804 / m - 515.450 / m"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "643.804 / m - 515.450 / m"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# These are `object` columns (strings)\n",
-    "string_columns = ['StateHoliday', 'StoreType', 'Assortment']\n",
+    "string_columns = [\"StateHoliday\", \"StoreType\", \"Assortment\"]\n",
     "\n",
     "for column in string_columns:\n",
     "    encoder = LabelEncoder()\n",
     "    train_split[column] = encoder.fit_transform(train_split[column])\n",
     "    test_split[column] = encoder.transform(test_split[column])"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Remove 'Year' column since it's irrelevant here\n",
-    "train_split.drop('Year', axis=1, inplace=True)\n",
-    "test_split.drop('Year', axis=1, inplace=True)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "train_split.drop(\"Year\", axis=1, inplace=True)\n",
+    "test_split.drop(\"Year\", axis=1, inplace=True)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "show(train_split)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "show(train_split)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 24,
-   "outputs": [],
-   "source": [
-    "label = 'Sales'"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "label = \"Sales\""
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "from xtime.estimators import Estimator\n",
-    "from xtime.ml import TaskType, RegressionTask\n",
-    "from xtime.datasets import (Dataset, DatasetSplit, DatasetMetadata)\n",
-    "from sklearn.dummy import DummyRegressor\n",
-    "\n",
-    "dataset = Dataset(\n",
-    "    metadata=DatasetMetadata(\n",
-    "        name='rossman_store_sales',\n",
-    "        version='NA',\n",
-    "        task=RegressionTask(ttype=TaskType.REGRESSION),\n",
-    "    ),\n",
-    "    splits={\n",
-    "        'train': DatasetSplit(x=train_split.drop(label, axis=1, inplace=False), y=train_split[label]),\n",
-    "        'valid': DatasetSplit(x=test_split.drop(label, axis=1, inplace=False), y=test_split[label])\n",
-    "    }\n",
-    ")\n",
-    "\n",
-    "estimator = Estimator()\n",
-    "estimator.model = DummyRegressor(strategy=\"mean\").fit(dataset.splits['train'].x, dataset.splits['train'].y)\n",
-    "\n",
-    "metrics = estimator.evaluate(dataset)\n",
-    "print(metrics)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.dummy import DummyRegressor\n",
+    "\n",
+    "from xtime.datasets import Dataset, DatasetMetadata, DatasetSplit\n",
+    "from xtime.estimators import Estimator\n",
+    "from xtime.ml import RegressionTask, TaskType\n",
+    "\n",
+    "dataset = Dataset(\n",
+    "    metadata=DatasetMetadata(\n",
+    "        name=\"rossman_store_sales\",\n",
+    "        version=\"NA\",\n",
+    "        task=RegressionTask(ttype=TaskType.REGRESSION),\n",
+    "    ),\n",
+    "    splits={\n",
+    "        \"train\": DatasetSplit(x=train_split.drop(label, axis=1, inplace=False), y=train_split[label]),\n",
+    "        \"valid\": DatasetSplit(x=test_split.drop(label, axis=1, inplace=False), y=test_split[label]),\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "estimator = Estimator()\n",
+    "estimator.model = DummyRegressor(strategy=\"mean\").fit(dataset.splits[\"train\"].x, dataset.splits[\"train\"].y)\n",
+    "\n",
+    "metrics = estimator.evaluate(dataset)\n",
+    "print(metrics)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "from sklearn.linear_model import LinearRegression\n",
     "\n",
     "estimator = Estimator()\n",
-    "estimator.model = LinearRegression(copy_X=False).fit(dataset.splits['train'].x, dataset.splits['train'].y)\n",
+    "estimator.model = LinearRegression(copy_X=False).fit(dataset.splits[\"train\"].x, dataset.splits[\"train\"].y)\n",
     "\n",
     "metrics = estimator.evaluate(dataset)\n",
     "print(metrics)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "is_executing": true
-    }
-   }
+   ]
   }
  ],
  "metadata": {

--- a/training/notebooks/datasets/telco_customer_churn.ipynb
+++ b/training/notebooks/datasets/telco_customer_churn.ipynb
@@ -3,194 +3,208 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
+    "\n",
     "import pandas as pd\n",
     "from pandasgui import show\n",
-    "from sklearn.preprocessing import LabelEncoder\n",
-    "from sklearn.model_selection import train_test_split"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.preprocessing import LabelEncoder"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
-    "data_dir = Path('~/.cache/kaggle/datasets/blastchar').expanduser()\n",
-    "file_name = 'WA_Fn-UseC_-Telco-Customer-Churn.csv'\n",
+    "data_dir = Path(\"~/.cache/kaggle/datasets/blastchar\").expanduser()\n",
+    "file_name = \"WA_Fn-UseC_-Telco-Customer-Churn.csv\"\n",
     "\n",
     "data_path = data_dir / file_name\n",
     "data: pd.DataFrame = pd.read_csv(data_path.as_posix())"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "# Analyze it with Pandas GUI library\n",
     "show(data)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "is_executing": true
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "from sklearn.preprocessing import OneHotEncoder\n",
-    "_ohe: OneHotEncoder = OneHotEncoder(sparse=False, dtype=int).fit(data['MultipleLines'].values.reshape(-1, 1))\n",
-    "print(_ohe.categories_)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.preprocessing import OneHotEncoder\n",
+    "\n",
+    "_ohe: OneHotEncoder = OneHotEncoder(sparse=False, dtype=int).fit(data[\"MultipleLines\"].values.reshape(-1, 1))\n",
+    "print(_ohe.categories_)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "_df = pd.DataFrame(\n",
-    "    _ohe.transform(data['MultipleLines'].values.reshape(-1, 1)),\n",
-    "    columns=[f'MultipleLines_{i}' for i in _ohe.categories_[0]]\n",
+    "    _ohe.transform(data[\"MultipleLines\"].values.reshape(-1, 1)),\n",
+    "    columns=[f\"MultipleLines_{i}\" for i in _ohe.categories_[0]],\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "show(pd.concat([_df, _df], axis=1))"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
-    "[f'MultipleLines_{i}' for i in _ohe.categories_[0]]"
-   ],
+    "[f\"MultipleLines_{i}\" for i in _ohe.categories_[0]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "# Pretty much all fields are categorical, except `customerID`. This one needs to be removed.\n",
-    "data.drop('customerID', axis=1, inplace=True)\n",
+    "data.drop(\"customerID\", axis=1, inplace=True)\n",
     "\n",
     "# This field has type int: convert to float\n",
-    "data['tenure'] = data['tenure'].astype(float)\n",
+    "data[\"tenure\"] = data[\"tenure\"].astype(float)\n",
     "\n",
     "# This field is object, convert to floating point numbers and remove nans\n",
     "_orig_size = len(data)\n",
-    "data['TotalCharges'] = pd.to_numeric(data['TotalCharges'], errors='coerce')\n",
-    "data.dropna(axis=0, how='any', inplace=True)\n",
+    "data[\"TotalCharges\"] = pd.to_numeric(data[\"TotalCharges\"], errors=\"coerce\")\n",
+    "data.dropna(axis=0, how=\"any\", inplace=True)\n",
     "print(f\"While casting TotalCharges to floats, {_orig_size - len(data)} instances have been removed.\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "is_executing": true
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# binary 0/1 (Churn - label)\n",
-    "data['gender'] = LabelEncoder().fit_transform(data['gender'])\n",
-    "for feature in ['Partner', 'Dependents', 'PhoneService', 'PaperlessBilling', 'Churn']:\n",
-    "    data[feature].replace({'No': 0, 'Yes': 1}, inplace=True)\n",
+    "data[\"gender\"] = LabelEncoder().fit_transform(data[\"gender\"])\n",
+    "for feature in [\"Partner\", \"Dependents\", \"PhoneService\", \"PaperlessBilling\", \"Churn\"]:\n",
+    "    data[feature].replace({\"No\": 0, \"Yes\": 1}, inplace=True)\n",
     "\n",
     "# categorical 0/1/2 or 0/1/2/3/4 (PaymentMethod)\n",
-    "for feature in ['MultipleLines', 'InternetService', 'OnlineSecurity', 'OnlineBackup', 'DeviceProtection', 'TechSupport', 'StreamingTV', 'StreamingMovies', 'Contract', 'PaymentMethod']:\n",
+    "for feature in [\n",
+    "    \"MultipleLines\",\n",
+    "    \"InternetService\",\n",
+    "    \"OnlineSecurity\",\n",
+    "    \"OnlineBackup\",\n",
+    "    \"DeviceProtection\",\n",
+    "    \"TechSupport\",\n",
+    "    \"StreamingTV\",\n",
+    "    \"StreamingMovies\",\n",
+    "    \"Contract\",\n",
+    "    \"PaymentMethod\",\n",
+    "]:\n",
     "    data[feature] = LabelEncoder().fit_transform(data[feature])"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "outputs": [],
-   "source": [
-    "label: str = 'Churn'\n",
-    "train, valid = train_test_split(data, train_size=0.8, random_state=0, stratify=data[label])"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "label: str = \"Churn\"\n",
+    "train, valid = train_test_split(data, train_size=0.8, random_state=0, stratify=data[label])"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "from xtime.estimators import Estimator\n",
-    "from xtime.ml import TaskType, ClassificationTask\n",
-    "from xtime.datasets import (Dataset, DatasetSplit, DatasetMetadata)\n",
-    "from sklearn.dummy import DummyClassifier\n",
-    "\n",
-    "dataset = Dataset(\n",
-    "    metadata=DatasetMetadata(\n",
-    "        name='telco_customer_churn',\n",
-    "        version='NA',\n",
-    "        task=ClassificationTask(type_=TaskType.BINARY_CLASSIFICATION),\n",
-    "    ),\n",
-    "    splits={\n",
-    "        'train': DatasetSplit(x=train.drop(label, axis=1, inplace=False), y=train[label]),\n",
-    "        'valid': DatasetSplit(x=valid.drop(label, axis=1, inplace=False), y=valid[label])\n",
-    "    }\n",
-    ")\n",
-    "\n",
-    "estimator = Estimator()\n",
-    "estimator.model = DummyClassifier(strategy=\"prior\").fit(dataset.splits['train'].x, dataset.splits['train'].y)\n",
-    "\n",
-    "metrics = estimator.evaluate(dataset)\n",
-    "print(metrics)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.dummy import DummyClassifier\n",
+    "\n",
+    "from xtime.datasets import Dataset, DatasetMetadata, DatasetSplit\n",
+    "from xtime.estimators import Estimator\n",
+    "from xtime.ml import ClassificationTask, TaskType\n",
+    "\n",
+    "dataset = Dataset(\n",
+    "    metadata=DatasetMetadata(\n",
+    "        name=\"telco_customer_churn\",\n",
+    "        version=\"NA\",\n",
+    "        task=ClassificationTask(type_=TaskType.BINARY_CLASSIFICATION),\n",
+    "    ),\n",
+    "    splits={\n",
+    "        \"train\": DatasetSplit(x=train.drop(label, axis=1, inplace=False), y=train[label]),\n",
+    "        \"valid\": DatasetSplit(x=valid.drop(label, axis=1, inplace=False), y=valid[label]),\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "estimator = Estimator()\n",
+    "estimator.model = DummyClassifier(strategy=\"prior\").fit(dataset.splits[\"train\"].x, dataset.splits[\"train\"].y)\n",
+    "\n",
+    "metrics = estimator.evaluate(dataset)\n",
+    "print(metrics)"
+   ]
   }
  ],
  "metadata": {

--- a/training/notebooks/datasets/year_prediction_msd.ipynb
+++ b/training/notebooks/datasets/year_prediction_msd.ipynb
@@ -3,90 +3,95 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "from pathlib import Path\n",
-    "from pandasgui import show\n",
-    "from xtime.datasets._year_prediction_msd import YearPredictionMSDBuilder"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import pandas as pd\n",
+    "from pandasgui import show\n",
+    "\n",
+    "from xtime.datasets._year_prediction_msd import YearPredictionMSDBuilder"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "outputs": [],
-   "source": [
-    "data_dir = Path('~/.cache/uci/datasets/00203').expanduser()\n",
-    "file_name = 'YearPredictionMSD.txt.zip'\n",
-    "if not (data_dir / file_name).is_file():\n",
-    "    YearPredictionMSDBuilder.download(data_dir, file_name)"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "data_dir = Path(\"~/.cache/uci/datasets/00203\").expanduser()\n",
+    "file_name = \"YearPredictionMSD.txt.zip\"\n",
+    "if not (data_dir / file_name).is_file():\n",
+    "    YearPredictionMSDBuilder.download(data_dir, file_name)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# All columns a numerical columns (continuous features). First column is the target column (year to predict / classify).\n",
     "data: pd.DataFrame = pd.read_csv((data_dir / file_name).as_posix(), header=None)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "outputs": [],
-   "source": [
-    "label = 'Year'"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "label = \"Year\""
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Dataset comes without columns. 90 attributes, 12 = timbre average, 78 = timbre covariance\n",
     "# The first value is the year (target), ranging from 1922 to 2011.\n",
-    "columns = ['Year']\n",
+    "columns = [\"Year\"]\n",
     "for i in range(12):\n",
-    "    columns.append(f'TimbreAvg_{i}')\n",
+    "    columns.append(f\"TimbreAvg_{i}\")\n",
     "for i in range(78):\n",
-    "    columns.append(f'TimbreCov_{i}')\n",
+    "    columns.append(f\"TimbreCov_{i}\")\n",
     "assert len(columns) == 91, f\"Fix me. Length = {len(columns)}\"\n",
     "\n",
     "data.columns = columns"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "show(data)"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "show(data)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "According to dataset [documentation](https://archive.ics.uci.edu/ml/datasets/yearpredictionmsd):\n",
     "> You should respect the following train / test split:\n",
@@ -94,104 +99,102 @@
     "> - test: last 51,630 examples\n",
     ">\n",
     "> It avoids the 'producer effect' by making sure no song from a given artist ends up in both the train and test set."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "train: pd.DataFrame = data.iloc[0:463715, :]\n",
     "test: pd.DataFrame = data.iloc[-51630:, :]"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "print(f\"train = {train.shape} test = {test.shape}\")"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
-    "from xtime.estimators import Estimator\n",
-    "from xtime.ml import TaskType, RegressionTask\n",
-    "from xtime.datasets import (Dataset, DatasetSplit, DatasetMetadata)\n",
     "from sklearn.dummy import DummyRegressor\n",
+    "\n",
+    "from xtime.datasets import Dataset, DatasetMetadata, DatasetSplit\n",
+    "from xtime.estimators import Estimator\n",
+    "from xtime.ml import RegressionTask, TaskType\n",
     "\n",
     "dataset = Dataset(\n",
     "    metadata=DatasetMetadata(\n",
-    "        name='year_prediction_msd',\n",
-    "        version='NA',\n",
+    "        name=\"year_prediction_msd\",\n",
+    "        version=\"NA\",\n",
     "        task=RegressionTask(ttype=TaskType.REGRESSION),\n",
     "    ),\n",
     "    splits={\n",
-    "        'train': DatasetSplit(x=train.drop(label, axis=1, inplace=False), y=train[label]),\n",
-    "        'valid': DatasetSplit(x=test.drop(label, axis=1, inplace=False), y=test[label])\n",
-    "    }\n",
+    "        \"train\": DatasetSplit(x=train.drop(label, axis=1, inplace=False), y=train[label]),\n",
+    "        \"valid\": DatasetSplit(x=test.drop(label, axis=1, inplace=False), y=test[label]),\n",
+    "    },\n",
     ")\n",
     "\n",
     "estimator = Estimator()\n",
-    "estimator.model = DummyRegressor(strategy=\"mean\").fit(dataset.splits['train'].x, dataset.splits['train'].y)\n",
+    "estimator.model = DummyRegressor(strategy=\"mean\").fit(dataset.splits[\"train\"].x, dataset.splits[\"train\"].y)\n",
     "\n",
     "metrics = estimator.evaluate(dataset)\n",
     "print(metrics)"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "is_executing": true
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "from sklearn.linear_model import LinearRegression\n",
     "\n",
     "estimator = Estimator()\n",
-    "estimator.model = LinearRegression(copy_X=False).fit(dataset.splits['train'].x, dataset.splits['train'].y)\n",
+    "estimator.model = LinearRegression(copy_X=False).fit(dataset.splits[\"train\"].x, dataset.splits[\"train\"].y)\n",
     "\n",
     "metrics = estimator.evaluate(dataset)\n",
     "print(metrics)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "is_executing": true
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# https://dainesanalytics.blog/2019/04/15/regression-model-for-song-year-prediction-using-python/\n",
     "# https://merelydoit.blog/2020/03/09/regression-deep-learning-model-for-song-year-prediction-using-tensorflow-take-2/\n",
     "# page 6: https://bdataanalytics.biomedcentral.com/track/pdf/10.1186/s41044-016-0010-4.pdf"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   }
  ],
  "metadata": {

--- a/training/poetry.lock
+++ b/training/poetry.lock
@@ -874,6 +874,21 @@ tabulate = ">=0.7.7"
 urllib3 = ">=1.26.7,<3"
 
 [[package]]
+name = "dataclasses-json"
+version = "0.6.4"
+description = "Easily serialize dataclasses to and from JSON."
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "dataclasses_json-0.6.4-py3-none-any.whl", hash = "sha256:f90578b8a3177f7552f4e1a6e535e84293cd5da421fcce0642d49c0d7bdf8df2"},
+    {file = "dataclasses_json-0.6.4.tar.gz", hash = "sha256:73696ebf24936560cca79a2430cbc4f3dd23ac7bf46ed17f38e5e5e7657a6377"},
+]
+
+[package.dependencies]
+marshmallow = ">=3.18.0,<4.0.0"
+typing-inspect = ">=0.4.0,<1"
+
+[[package]]
 name = "debugpy"
 version = "1.8.1"
 description = "An implementation of the Debug Adapter Protocol for Python"
@@ -1744,6 +1759,19 @@ files = [
 ]
 
 [[package]]
+name = "intervaltree"
+version = "3.1.0"
+description = "Editable interval tree data structure for Python 2 and 3"
+optional = false
+python-versions = "*"
+files = [
+    {file = "intervaltree-3.1.0.tar.gz", hash = "sha256:902b1b88936918f9b2a19e0e5eb7ccb430ae45cde4f39ea4b36932920d33952d"},
+]
+
+[package.dependencies]
+sortedcontainers = ">=2.0,<3.0"
+
+[[package]]
 name = "ipykernel"
 version = "6.29.3"
 description = "IPython Kernel for Jupyter"
@@ -2386,6 +2414,48 @@ files = [
 ]
 
 [[package]]
+name = "libcst"
+version = "1.2.0"
+description = "A concrete syntax tree with AST-like properties for Python 3.0 through 3.12 programs."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "libcst-1.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c0149d24a455536ff2e41b3a48b16d3ebb245e28035013c91bd868def16592a0"},
+    {file = "libcst-1.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ba24b8cf789db6b87c6e23a6c6365f5f73cb7306d929397581d5680149e9990c"},
+    {file = "libcst-1.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2bbb4e442224da46b59a248d7d632ed335eae023a921dea1f5c72d2a059f6be9"},
+    {file = "libcst-1.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f4919978c2b395079b64d8a654357854767adbabab13998b39c1f0bc67da8a7"},
+    {file = "libcst-1.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5e54389abdea995b39ee96ad736ed1b0b8402ed30a7956b7a279c10baf0c0294"},
+    {file = "libcst-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:1d45718f7e7a1405a16fd8e7fc75c365120001b6928bfa3c4112f7e533990b9a"},
+    {file = "libcst-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f080e9af843ff609f8f35fc7275c8bf08b02c31115e7cd5b77ca3b6a56c75096"},
+    {file = "libcst-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3c7c0edfe3b878d64877671261c7b3ffe9d23181774bfad5d8fcbdbbbde9f064"},
+    {file = "libcst-1.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b5fecb2b26fa3c1efe6e05ef1420522bd31bb4dae239e4c41fdf3ddbd853aeb"},
+    {file = "libcst-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:968b93400e66e6711a29793291365e312d206dbafd3fc80219cfa717f0f01ad5"},
+    {file = "libcst-1.2.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e01879aa8cd478bb8b1e4285cfd0607e64047116f7ab52bc2a787cde584cd686"},
+    {file = "libcst-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:b4066dcadf92b183706f81ae0b4342e7624fc1d9c5ca2bf2b44066cb74bf863f"},
+    {file = "libcst-1.2.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5c0d548d92c6704bb07ce35d78c0e054cdff365def0645c1b57c856c8e112bb4"},
+    {file = "libcst-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:82373a35711a8bb2a664dba2b7aeb20bbcce92a4db40af964e9cb2b976f989e7"},
+    {file = "libcst-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cb92398236566f0b73a0c73f8a41a9c4906c793e8f7c2745f30e3fb141a34b5"},
+    {file = "libcst-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13ca9fe82326d82feb2c7b0f5a320ce7ed0d707c32919dd36e1f40792459bf6f"},
+    {file = "libcst-1.2.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dded0e4f2e18150c4b07fedd7ef84a9abc7f9bd2d47cc1c485248ee1ec58e5cc"},
+    {file = "libcst-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:dece0362540abfc39cd2cf5c98cde238b35fd74a1b0167e2563e4b8bb5f47489"},
+    {file = "libcst-1.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c80f36f4a02d530e28eac7073aabdea7c6795fc820773a02224021d79d164e8b"},
+    {file = "libcst-1.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8b56130f18aca9a98b3bcaf5962b2b26c2dcdd6d5132decf3f0b0b635f4403ba"},
+    {file = "libcst-1.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4973a9d509cf1a59e07fac55a98f70bc4fd35e09781dffb3ec93ee32fc0de7af"},
+    {file = "libcst-1.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6dd388c74c04434b41e3b25fc4a0fafa3e6abf91f97181df55e8f8327fd903cc"},
+    {file = "libcst-1.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:38fbd56f885e1f77383a6d1d798a917ffbc6d28dc6b1271eddbf8511c194213e"},
+    {file = "libcst-1.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:f2342634f6c61fc9076dc0baf21e9cf5ef0195a06e1e95c0c9dc583ba3a30d00"},
+    {file = "libcst-1.2.0.tar.gz", hash = "sha256:71dd69fff76e7edaf8fae0f63ffcdbf5016e8cd83165b1d0688d6856aa48186a"},
+]
+
+[package.dependencies]
+pyyaml = ">=5.2"
+typing-extensions = ">=3.7.4.2"
+typing-inspect = ">=0.4.0"
+
+[package.extras]
+dev = ["Sphinx (>=5.1.1)", "black (==23.12.1)", "build (>=0.10.0)", "coverage (>=4.5.4)", "fixit (==2.1.0)", "flake8 (==7.0.0)", "hypothesis (>=4.36.0)", "hypothesmith (>=0.0.4)", "jinja2 (==3.1.3)", "jupyter (>=1.0.0)", "maturin (>=0.8.3,<1.5)", "nbsphinx (>=0.4.2)", "prompt-toolkit (>=2.0.9)", "pyre-check (==0.9.18)", "setuptools-rust (>=1.5.2)", "setuptools-scm (>=6.0.1)", "slotscheck (>=0.7.1)", "sphinx-rtd-theme (>=0.4.3)", "ufmt (==2.3.0)", "usort (==1.0.7)"]
+
+[[package]]
 name = "lightgbm"
 version = "3.3.5"
 description = "LightGBM Python Package"
@@ -2543,6 +2613,25 @@ files = [
     {file = "MarkupSafe-2.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5"},
     {file = "MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"},
 ]
+
+[[package]]
+name = "marshmallow"
+version = "3.21.1"
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "marshmallow-3.21.1-py3-none-any.whl", hash = "sha256:f085493f79efb0644f270a9bf2892843142d80d7174bbbd2f3713f2a589dc633"},
+    {file = "marshmallow-3.21.1.tar.gz", hash = "sha256:4e65e9e0d80fc9e609574b9983cf32579f305c718afb30d7233ab818571768c3"},
+]
+
+[package.dependencies]
+packaging = ">=17.0"
+
+[package.extras]
+dev = ["marshmallow[tests]", "pre-commit (>=3.5,<4.0)", "tox"]
+docs = ["alabaster (==0.7.16)", "autodocsumm (==0.2.12)", "sphinx (==7.2.6)", "sphinx-issues (==4.0.0)", "sphinx-version-warning (==1.1.2)"]
+tests = ["pytest", "pytz", "simplejson"]
 
 [[package]]
 name = "matplotlib"
@@ -2758,7 +2847,6 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
-    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
     {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
 ]
 
@@ -4018,6 +4106,45 @@ PyQt5 = ">=5.15"
 PyQt5-sip = ">=12.8,<13"
 
 [[package]]
+name = "pyre-check"
+version = "0.9.19"
+description = "A performant type checker for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyre-check-0.9.19.tar.gz", hash = "sha256:0c6b24c9c0950588dab056a13f25322a76e302b575bee479a3ad738d74c4a135"},
+    {file = "pyre_check-0.9.19-py3-none-macosx_10_11_x86_64.whl", hash = "sha256:1189a5ce672684ed79929783e80483ed4ed958e4f94c8f6fbe2dae306f2fdf6a"},
+    {file = "pyre_check-0.9.19-py3-none-manylinux1_x86_64.whl", hash = "sha256:de580f56e6241d792ec3b164b557610023b40914f0506cf166189989e2d13d0c"},
+]
+
+[package.dependencies]
+click = ">=8.0"
+dataclasses-json = "*"
+intervaltree = "*"
+libcst = "*"
+psutil = "*"
+pyre-extensions = ">=0.0.29"
+tabulate = "*"
+testslide = ">=2.7.0"
+typing-extensions = "*"
+typing-inspect = "*"
+
+[[package]]
+name = "pyre-extensions"
+version = "0.0.30"
+description = "Type system extensions for use with the pyre type checker"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pyre-extensions-0.0.30.tar.gz", hash = "sha256:ba7923c486e089afb37a10623a8f4ae82d73cff42426d711c48af070e5bc31b2"},
+    {file = "pyre_extensions-0.0.30-py3-none-any.whl", hash = "sha256:32b37ede4eed0ea879fdd6d84e0c7811e129f19b76614f1be3a6b47f9a4b1fa0"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+typing-inspect = "*"
+
+[[package]]
 name = "pyreadline3"
 version = "3.4.1"
 description = "A python implementation of GNU readline."
@@ -4183,6 +4310,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4653,6 +4781,32 @@ files = [
 pyasn1 = ">=0.1.3"
 
 [[package]]
+name = "ruff"
+version = "0.3.4"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.3.4-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:60c870a7d46efcbc8385d27ec07fe534ac32f3b251e4fc44b3cbfd9e09609ef4"},
+    {file = "ruff-0.3.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6fc14fa742e1d8f24910e1fff0bd5e26d395b0e0e04cc1b15c7c5e5fe5b4af91"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3ee7880f653cc03749a3bfea720cf2a192e4f884925b0cf7eecce82f0ce5854"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cf133dd744f2470b347f602452a88e70dadfbe0fcfb5fd46e093d55da65f82f7"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3f3860057590e810c7ffea75669bdc6927bfd91e29b4baa9258fd48b540a4365"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:986f2377f7cf12efac1f515fc1a5b753c000ed1e0a6de96747cdf2da20a1b369"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4fd98e85869603e65f554fdc5cddf0712e352fe6e61d29d5a6fe087ec82b76c"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:64abeed785dad51801b423fa51840b1764b35d6c461ea8caef9cf9e5e5ab34d9"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df52972138318bc7546d92348a1ee58449bc3f9eaf0db278906eb511889c4b50"},
+    {file = "ruff-0.3.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:98e98300056445ba2cc27d0b325fd044dc17fcc38e4e4d2c7711585bd0a958ed"},
+    {file = "ruff-0.3.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:519cf6a0ebed244dce1dc8aecd3dc99add7a2ee15bb68cf19588bb5bf58e0488"},
+    {file = "ruff-0.3.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:bb0acfb921030d00070539c038cd24bb1df73a2981e9f55942514af8b17be94e"},
+    {file = "ruff-0.3.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cf187a7e7098233d0d0c71175375c5162f880126c4c716fa28a8ac418dcf3378"},
+    {file = "ruff-0.3.4-py3-none-win32.whl", hash = "sha256:af27ac187c0a331e8ef91d84bf1c3c6a5dea97e912a7560ac0cef25c526a4102"},
+    {file = "ruff-0.3.4-py3-none-win_amd64.whl", hash = "sha256:de0d5069b165e5a32b3c6ffbb81c350b1e3d3483347196ffdf86dc0ef9e37dd6"},
+    {file = "ruff-0.3.4-py3-none-win_arm64.whl", hash = "sha256:6810563cc08ad0096b57c717bd78aeac888a1bfd38654d9113cb3dc4d3f74232"},
+    {file = "ruff-0.3.4.tar.gz", hash = "sha256:f0f4484c6541a99862b693e13a151435a279b271cff20e37101116a21e2a1ad1"},
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.2.2"
 description = "A set of python modules for machine learning and data mining"
@@ -4888,6 +5042,17 @@ python-versions = ">=3.7"
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 
 [[package]]
@@ -5161,6 +5326,24 @@ test = ["pre-commit", "pytest (>=7.0)", "pytest-timeout"]
 typing = ["mypy (>=1.6,<2.0)", "traitlets (>=5.11.1)"]
 
 [[package]]
+name = "testslide"
+version = "2.7.1"
+description = "A test framework for Python that makes mocking and iterating over code with tests a breeze"
+optional = false
+python-versions = "*"
+files = [
+    {file = "TestSlide-2.7.1.tar.gz", hash = "sha256:d25890d5c383f673fac44a5f9e2561b7118d04f29f2c2b3d4f549e6db94cb34d"},
+]
+
+[package.dependencies]
+psutil = ">=5.6.7"
+Pygments = ">=2.2.0"
+typeguard = "<3.0"
+
+[package.extras]
+build = ["black", "coverage", "coveralls", "flake8", "ipython", "isort (>=5.1,<6.0)", "mypy (==0.991)", "sphinx", "sphinx-autobuild", "sphinx-kr-theme", "twine"]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.3.0"
 description = "threadpoolctl"
@@ -5296,6 +5479,21 @@ matrixprofile = ["matrixprofile (>=1.1.10,<2.0.0)"]
 testing = ["dask[dataframe] (>=2.9.0)", "distributed (>=2.11.0)", "ipython (>=5.3.0)", "matplotlib (>=2.0.0)", "mock (>=2.0.0)", "notebook (>=4.4.1)", "pandas-datareader (>=0.5.0)", "pre-commit", "pytest (>=4.4.0)", "pytest-benchmark (>=3.0.0)", "pytest-cov (>=2.6.1)", "pytest-xdist (>=1.26.1)", "seaborn (>=0.7.1)"]
 
 [[package]]
+name = "typeguard"
+version = "2.13.3"
+description = "Run-time type checker for Python"
+optional = false
+python-versions = ">=3.5.3"
+files = [
+    {file = "typeguard-2.13.3-py3-none-any.whl", hash = "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1"},
+    {file = "typeguard-2.13.3.tar.gz", hash = "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4"},
+]
+
+[package.extras]
+doc = ["sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
+test = ["mypy", "pytest", "typing-extensions"]
+
+[[package]]
 name = "types-python-dateutil"
 version = "2.9.0.20240316"
 description = "Typing stubs for python-dateutil"
@@ -5316,6 +5514,21 @@ files = [
     {file = "typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475"},
     {file = "typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"},
 ]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+description = "Runtime inspection utilities for typing module."
+optional = false
+python-versions = "*"
+files = [
+    {file = "typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f"},
+    {file = "typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=0.3.0"
+typing-extensions = ">=3.7.4"
 
 [[package]]
 name = "uri-template"
@@ -5803,4 +6016,4 @@ xgboost = ["xgboost"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "5a9ad588111d03310e326018c9d2605f41a84dcd1955ceb62810b7267157098d"
+content-hash = "152328700d883a896a70210d1ae90ca78aa17614b536cdb93077a9937edb85ad"

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -35,16 +35,14 @@ lightgbm = { version = "3.3.5", optional = true }  # Gradient boosting trees - L
 xgboost = { version = "2.0.3", optional = true }   # Gradient boosting trees - XGBoost library.
 
 [tool.poetry.group.dev.dependencies]
-black = "24.1.1"
-isort = "5.13.2"
-flake8 = "7.0.0"
-Flake8-pyproject = "1.2.3"     # This enables flake8 to load its config from pyproject file.
+pyre-check = "0.9.19"          # Type checking tool (`pyre --search-path $(python -c 'import site; print(site.getsitepackages()[0])') check`)
+ruff = "0.3.4"                 # Replace black, isort, flake with `ruff check [--fix]` and `ruff format`
 pytest = "8.0.0"               # Running unit tests (`pytest ./tests` instead of `python -m unittest`)
 pytest-xdist = "3.5.0"         # Parallel `pytest` (`python -m pytest -n auto ./tests`)
 
 [tool.poetry.group.eda.dependencies]
 jupyter = "1.0.0"
-pandasgui = "0.2.14"
+pandasgui = "0.2.14"           # FIXME: This does not work in Jupyter notebooks on Linux headless systems.
 PyQt5 = "5.15.2"               # Fixes "inable to find installation candidates for pyqt5-qt5 (x.x.x)" in Ubuntu
 
 [tool.poetry.extras]
@@ -60,17 +58,21 @@ models = ["catboost", "lightgbm", "xgboost"]
 
 all = ["openml", "tsfresh", "catboost", "lightgbm", "xgboost"]
 
-[tool.black]
-# python -m black --config pyproject.toml ./xtime ./tests
+
+[tool.ruff]
 line-length = 120
-skip-magic-trailing-comma = true
+indent-width = 4
+target-version = 'py39'
+extend-include = ["*.ipynb"]
 
-[tool.isort]
-# python -m isort ./xtime ./tests
-profile = "black"
 
-[tool.flake8]
-max-line-length = 120
+[tool.ruff.format]
+indent-style = "space"
+
+
+[tool.ruff.lint]
+extend-select = ["I"]  # I - isort
+
 
 [tool.pytest.ini_options]
 markers = [

--- a/training/tests/contrib/test_mlflow_ext.py
+++ b/training/tests/contrib/test_mlflow_ext.py
@@ -14,4 +14,3 @@
 # limitations under the License.
 ###
 
-from xtime.contrib.mlflow_ext import MLflow

--- a/training/tests/contrib/test_tune_ext.py
+++ b/training/tests/contrib/test_tune_ext.py
@@ -20,11 +20,11 @@ import ray.tune.search.sample as sample
 import yaml
 
 from xtime.contrib.tune_ext import (
-    Analysis,
+    Analysis,  # noqa
     RandomVarDomain,
-    RayTuneDriverToMLflowLoggerCallback,
+    RayTuneDriverToMLflowLoggerCallback,  # noqa
     add_representers,
-    gpu_available,
+    gpu_available,  # noqa
 )
 
 
@@ -81,7 +81,10 @@ class TestYamlRepresenters(TestCase):
         self.assertIn(domain_t, {sample.Integer, sample.Float}, "Invalid domain type.")
 
         def _check(
-            _rv: sample.Domain, _sampler_t: t.Optional[t.Type], _q: t.Optional = None, _base: t.Optional = None
+            _rv: t.Union[sample.Integer, sample.Float],
+            _sampler_t: t.Optional[t.Type],
+            _q: t.Optional[int] = None,
+            _base: t.Optional[int] = None,
         ) -> None:
             self.assertIsInstance(_rv, domain_t)
             self.assertEqual(lower, _rv.lower)
@@ -119,7 +122,7 @@ class TestYamlRepresenters(TestCase):
         mean, sd = 1.1, 0.45
         q = 0.1
 
-        def _check(_rv: sample.Float, _sampler_t: t.Optional[t.Type], _q: t.Optional = None) -> None:
+        def _check(_rv: sample.Float, _sampler_t: t.Optional[t.Type], _q: t.Optional[float] = None) -> None:
             self.assertEqual(float("-inf"), _rv.lower)
             self.assertEqual(float("+inf"), _rv.upper)
             self._check_sampler(type(_rv), _rv.sampler, sampler_type=_sampler_t, q=_q, mean=mean, sd=sd)
@@ -136,7 +139,7 @@ class TestYamlRepresenters(TestCase):
         sampler: t.Optional[sample.Sampler],
         sampler_type: t.Optional[t.Type] = None,
         base: t.Optional[int] = None,
-        q: t.Optional[int] = None,
+        q: t.Optional[t.Union[int, float]] = None,
         mean: t.Optional[float] = None,
         sd: t.Optional[float] = None,
     ) -> None:

--- a/training/tests/datasets/test_dataset.py
+++ b/training/tests/datasets/test_dataset.py
@@ -21,13 +21,9 @@ from unittest import TestCase, mock
 from xtime.contrib.unittest_ext import with_temp_work_dir
 from xtime.datasets.dataset import (
     Dataset,
-    DatasetBuilder,
     DatasetFactory,
-    DatasetMetadata,
     DatasetPrerequisites,
-    DatasetSplit,
     RegisteredDatasetFactory,
-    SerializedDatasetFactory,
 )
 from xtime.errors import DatasetError
 

--- a/training/tests/datasets/test_preprocessing.py
+++ b/training/tests/datasets/test_preprocessing.py
@@ -75,7 +75,6 @@ class TestTimeSeriesEncoder(TestCase):
 
 
 class TestTimeSeriesEncoderV1(TestCase):
-
     NUM_FEATURES = 19
 
     def test_features(self) -> None:

--- a/training/tests/hparams/test_recommender.py
+++ b/training/tests/hparams/test_recommender.py
@@ -23,7 +23,6 @@ TaskLike = t.TypeVar("TaskLike", bound=Task)
 
 
 class TestRecommender(TestCase):
-
     def test_default_lightgbm(self):
         params: t.Dict = get_hparams("auto:default:model=lightgbm;task=multi_class_classification")
         self.assertIsInstance(params, dict)

--- a/training/tests/stages/test_describe.py
+++ b/training/tests/stages/test_describe.py
@@ -14,4 +14,3 @@
 # limitations under the License.
 ###
 
-from xtime.stages.describe import describe

--- a/training/tests/stages/test_search_hp.py
+++ b/training/tests/stages/test_search_hp.py
@@ -14,12 +14,3 @@
 # limitations under the License.
 ###
 
-from xtime.stages.search_hp import (
-    _get_metrics_for_best_trial,
-    _init_search_algorithm,
-    _save_best_trial_info,
-    _save_summary,
-    _set_run_status,
-    _set_tags,
-    search_hp,
-)

--- a/training/tests/test_cli.py
+++ b/training/tests/test_cli.py
@@ -25,7 +25,6 @@ from click.testing import CliRunner, Result
 from xtime.datasets import DatasetBuilder, RegisteredDatasetFactory
 from xtime.errors import ErrorCode
 from xtime.main import (
-    _run_search_hp_pipeline,
     cli,
     dataset_describe,
     dataset_list,
@@ -67,7 +66,7 @@ class TestMain(TestCase):
         ]
         for cli_func in cli_funcs:
             self.assertIsInstance(cli_func, BaseCommand)
-            result: Result = CliRunner().invoke(cli_func, [f"--help"])
+            result: Result = CliRunner().invoke(cli_func, ["--help"])
             self.assertEqual(result.exit_code, 0)
 
     def test_dataset_describe(self) -> None:

--- a/training/tests/test_io.py
+++ b/training/tests/test_io.py
@@ -14,4 +14,3 @@
 # limitations under the License.
 ###
 
-from xtime.io import IO, PathLike, encode, to_path

--- a/training/tests/test_ml.py
+++ b/training/tests/test_ml.py
@@ -18,7 +18,7 @@ import uuid
 from unittest import TestCase
 
 from xtime.contrib.unittest_ext import check_enum
-from xtime.ml import METRICS, ClassificationTask, Feature, FeatureType, RegressionTask, Task, TaskType, _Metrics
+from xtime.ml import METRICS, ClassificationTask, Feature, FeatureType, RegressionTask, Task, TaskType
 
 
 class TestML(TestCase):

--- a/training/xtime/contrib/mlflow_ext.py
+++ b/training/xtime/contrib/mlflow_ext.py
@@ -82,7 +82,7 @@ class MLflow(object):
     def get_runs(
         client: t.Optional[MlflowClient] = None,
         experiment_ids: t.Optional[t.List[str]] = None,
-        filter_string: t.Optional[str] = None,
+        filter_string: str = "",
     ) -> t.List[Run]:
         """Return MLflow runs that match given query (filter string).
 
@@ -102,7 +102,9 @@ class MLflow(object):
         page_token: t.Optional[str] = None
         while True:
             _runs: PagedList[Run] = client.search_runs(
-                experiment_ids=experiment_ids, filter_string=filter_string, page_token=page_token
+                experiment_ids=experiment_ids if experiment_ids is not None else MLflow.get_experiment_ids(client),
+                filter_string=filter_string,
+                page_token=page_token,
             )
             runs.extend(_runs)
             page_token = _runs.token

--- a/training/xtime/datasets/_eye_movements.py
+++ b/training/xtime/datasets/_eye_movements.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
+import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
 
@@ -34,7 +35,7 @@ class EyeMovementsBuilder(DatasetBuilder):
     def _check_pre_requisites(self) -> None:
         DatasetPrerequisites.check_openml(self.NAME, "openml.org/d/1044")
 
-    def _build_default_dataset(self) -> Dataset:
+    def _build_default_dataset(self, **kwargs) -> Dataset:
         """Create `eye_movements` train/valid/test datasets.
 
             Dataset source: openml.org/d/1044
@@ -66,6 +67,8 @@ class EyeMovementsBuilder(DatasetBuilder):
 
         # Load from local cache (x - pandas data frame, y - pandas series)
         x, y, _, _ = data.get_data(target=data.default_target_attribute, dataset_format="dataframe")
+        assert isinstance(x, pd.DataFrame), f"Expecting x to be of type pd.DataFrame (type = {type(x)})."
+        assert isinstance(y, pd.Series), f"Expecting y to be of type pd.Series (type = {type(y)})."
 
         # Encode labels. Move from `category` type to int type with labels [0, 1, 2]
         y = y.astype(int)

--- a/training/xtime/datasets/_forest_cover_type.py
+++ b/training/xtime/datasets/_forest_cover_type.py
@@ -40,7 +40,7 @@ class ForestCoverTypeBuilder(DatasetBuilder):
         super().__init__()
         self.builders.update(default=self._build_default_dataset, numerical=self._build_numerical_dataset)
 
-    def _build_default_dataset(self) -> Dataset:
+    def _build_default_dataset(self, **kwargs) -> Dataset:
         """Create `Forest Cover Type (cover_type)` train/valid/test datasets.
 
             Dataset source: https://www.kaggle.com/c/forest-cover-type-prediction

--- a/training/xtime/datasets/_gas_concentrations.py
+++ b/training/xtime/datasets/_gas_concentrations.py
@@ -35,7 +35,7 @@ class GasConcentrationsBuilder(DatasetBuilder):
     def _check_pre_requisites(self) -> None:
         DatasetPrerequisites.check_openml(self.NAME, "openml.org/d/1477")
 
-    def _build_default_dataset(self) -> Dataset:
+    def _build_default_dataset(self, **kwargs) -> Dataset:
         """Create `gas-drift-different-concentrations` train/valid/test datasets.
 
             Dataset source: openml.org/d/1477
@@ -64,6 +64,8 @@ class GasConcentrationsBuilder(DatasetBuilder):
 
         # Load from local cache
         x, y, _, _ = data.get_data(target=data.default_target_attribute, dataset_format="dataframe")
+        assert isinstance(x, pd.DataFrame), f"Expecting x to be of type pd.DataFrame (type = {type(x)})."
+        assert isinstance(y, pd.Series), f"Expecting y to be of type pd.Series (type = {type(y)})."
 
         # Encode labels (it's categorical column with values from [1, 6])
         y = pd.Series(LabelEncoder().fit_transform(y), index=y.index, name=y.name)

--- a/training/xtime/datasets/_gesture_phase.py
+++ b/training/xtime/datasets/_gesture_phase.py
@@ -35,7 +35,7 @@ class GesturePhaseSegmentationBuilder(DatasetBuilder):
     def _check_pre_requisites(self) -> None:
         DatasetPrerequisites.check_openml(self.NAME, "openml.org/d/4538")
 
-    def _build_default_dataset(self) -> Dataset:
+    def _build_default_dataset(self, **kwargs) -> Dataset:
         """Create `Gesture Phase Segmentation Processed` train/valid/test datasets.
 
             Dataset source: openml.org/d/4538
@@ -67,6 +67,8 @@ class GesturePhaseSegmentationBuilder(DatasetBuilder):
         # categorical_indicator  t.List[bool]  32          No categorical features
         # attributed_names       t.List[str]   32          5 categories: ['D', 'P', 'S', 'H', 'R']
         x, y, _, _ = data.get_data(target=data.default_target_attribute, dataset_format="dataframe")
+        assert isinstance(x, pd.DataFrame), f"Expecting x to be of type pd.DataFrame (type = {type(x)})."
+        assert isinstance(y, pd.Series), f"Expecting y to be of type pd.Series (type = {type(y)})."
 
         # Encode labels
         y = pd.Series(LabelEncoder().fit_transform(y), index=y.index, name=y.name)

--- a/training/xtime/datasets/_rossmann_store_sales.py
+++ b/training/xtime/datasets/_rossmann_store_sales.py
@@ -51,7 +51,7 @@ class RossmannStoreSalesBuilder(DatasetBuilder):
                 f"{(self._data_dir / self._store_file).as_posix()}."
             )
 
-    def _build_default_dataset(self) -> Dataset:
+    def _build_default_dataset(self, **kwargs) -> Dataset:
         train: pd.DataFrame = pd.read_csv((self._data_dir / self._train_file).as_posix())
         store: pd.DataFrame = pd.read_csv((self._data_dir / self._store_file).as_posix())
 

--- a/training/xtime/datasets/_telco_customer_churn.py
+++ b/training/xtime/datasets/_telco_customer_churn.py
@@ -49,7 +49,7 @@ class TelcoCustomerChurnBuilder(DatasetBuilder):
                 f"must exist: {(self._data_dir / self._data_file).as_posix()}."
             )
 
-    def _build_default_dataset(self) -> Dataset:
+    def _build_default_dataset(self, **kwargs) -> Dataset:
         """Create `blastchar (Telco Customer Churn)` train/valid/test datasets.
 
             Dataset source: https://www.kaggle.com/datasets/blastchar/telco-customer-churn

--- a/training/xtime/datasets/_year_prediction_msd.py
+++ b/training/xtime/datasets/_year_prediction_msd.py
@@ -36,7 +36,7 @@ class YearPredictionMSDBuilder(DatasetBuilder):
         super().__init__()
         self.builders.update(default=self._build_default_dataset)
 
-    def _build_default_dataset(self) -> Dataset:
+    def _build_default_dataset(self, **kwargs) -> Dataset:
         """
 
         https://archive.ics.uci.edu/ml/datasets/yearpredictionmsd

--- a/training/xtime/datasets/preprocessing.py
+++ b/training/xtime/datasets/preprocessing.py
@@ -179,8 +179,9 @@ class TimeSeries:
         if not has_transform:
             # With transform (such as computing segment mode) we can't conduct these tests.
             assert _windows.ndim == 3, f"Invalid train windows shape (shape={_windows.shape})."
-            assert _windows.shape[1] == window_size, \
-                f"Invalid train windows shape (shape={_windows.shape}, window_size={window_size})."
+            assert (
+                _windows.shape[1] == window_size
+            ), f"Invalid train windows shape (shape={_windows.shape}, window_size={window_size})."
         return _windows
 
 

--- a/training/xtime/errors.py
+++ b/training/xtime/errors.py
@@ -43,8 +43,10 @@ class ErrorCode:
     GENERIC_ERROR = 2
     CONFIGURATION_ERROR = 50
     ESTIMATOR_ERROR = 100
+    ESTIMATOR_MISSING_PREREQUISITES_ERROR = 101
     DATASET_ERROR = 150
     DATASET_MISSING_PREREQUISITES_ERROR = 151
+    DATASET_MISSING_TRAIN_EVAL_SPLITS_ERROR = 152
 
 
 class XTimeError(Exception):
@@ -66,6 +68,12 @@ class EstimatorError(XTimeError):
     def __init__(self, message: str) -> None:
         super().__init__(message, error_code=ErrorCode.ESTIMATOR_ERROR)
 
+    @classmethod
+    def missing_prerequisites(cls, message: str) -> "EstimatorError":
+        error = EstimatorError(message)
+        error._error_code = ErrorCode.ESTIMATOR_MISSING_PREREQUISITES_ERROR
+        return error
+
 
 class DatasetError(XTimeError):
     def __init__(self, message: str) -> None:
@@ -75,4 +83,14 @@ class DatasetError(XTimeError):
     def missing_prerequisites(cls, message: str) -> "DatasetError":
         error = DatasetError(message)
         error._error_code = ErrorCode.DATASET_MISSING_PREREQUISITES_ERROR
+        return error
+
+    @classmethod
+    def missing_train_eval_splits(cls, dataset: str, train_split: t.Any, eval_split: t.Any) -> "DatasetError":
+        message: str = (
+            f"Missing train and/or eval split (dataset={dataset}, "
+            f"train_split_is_none={train_split is None}, eval_split_is_none={eval_split is None})."
+        )
+        error = DatasetError(message)
+        error._error_code = ErrorCode.DATASET_MISSING_TRAIN_EVAL_SPLITS_ERROR
         return error

--- a/training/xtime/io.py
+++ b/training/xtime/io.py
@@ -97,8 +97,9 @@ class IO(object):
 
     @staticmethod
     def work_dir() -> Path:
-        if mlflow.active_run() is not None:
-            return Path(local_file_uri_to_path(mlflow.active_run().info.artifact_uri))
+        active_run: t.Optional[mlflow.ActiveRun] = mlflow.active_run()
+        if active_run is not None:
+            return Path(local_file_uri_to_path(active_run.info.artifact_uri))
         return Path.cwd()
 
     @staticmethod
@@ -170,12 +171,13 @@ class IO(object):
 
     @staticmethod
     def save_data_frame(df: pd.DataFrame, file_path: t.Union[str, Path]) -> None:
-        if file_path.endswith(".yaml"):
+        name: str = to_path(file_path).name
+        if name.endswith(".yaml"):
             IO.save_yaml(df.to_dict("records"), file_path)
-        elif file_path.endswith(".json"):
+        elif name.endswith(".json"):
             IO.save_yaml(df.to_dict("records"), file_path)
         else:
-            if not file_path.endswith((".csv", ".csv.gz")):
+            if not name.endswith((".csv", ".csv.gz")):
                 raise NotImplementedError(f"Do not know how to serialize data frame to `{file_path}`.")
             df.to_csv(file_path)
 

--- a/training/xtime/ml.py
+++ b/training/xtime/ml.py
@@ -41,7 +41,7 @@ class TaskType(str, Enum):
         return self is TaskType.REGRESSION
 
 
-class Task(object):
+class Task:
     def __init__(self, type_: t.Union[TaskType, str]) -> None:
         self.type = TaskType(type_)
 
@@ -49,7 +49,7 @@ class Task(object):
         return {"type": self.type.value}
 
     @staticmethod
-    def from_json(json_obj: t.Dict) -> t.Union["ClassificationTask", "RegressionTask"]:
+    def from_json(json_obj: t.Dict) -> "Task":
         json_obj = copy.deepcopy(json_obj)
         type_: TaskType = TaskType(json_obj.pop("type"))
         if type_.classification():
@@ -80,7 +80,7 @@ class ClassificationTask(Task):
             )
 
         super().__init__(type_)
-        self.num_classes = num_classes
+        self.num_classes: int = num_classes
 
     def to_json(self) -> t.Dict:
         _dict = super().to_json()

--- a/training/xtime/stages/describe.py
+++ b/training/xtime/stages/describe.py
@@ -30,11 +30,13 @@ def describe(report_type: str, run: t.Optional[str] = None, file: t.Optional[str
 
     summary: t.Optional[t.Union[t.Dict, pd.DataFrame]] = None
     if report_type == "summary":
-        summary: t.Dict = Analysis.get_summary(run)
+        assert run is not None, "The `run` can't be none here."
+        summary = Analysis.get_summary(run)
     elif report_type == "best_trial":
-        summary: t.Dict = Analysis.get_best_trial(run)
+        assert run is not None, "The `run` can't be none here."
+        summary = Analysis.get_best_trial(run)
     elif report_type == "final_trials":
-        summary: pd.DataFrame = Analysis.get_final_trials()
+        summary = Analysis.get_final_trials()
 
     if file:
         IO.save_to_file(summary, file)

--- a/training/xtime/stages/train.py
+++ b/training/xtime/stages/train.py
@@ -51,7 +51,7 @@ def train(dataset: str, model: str, hparams: t.Optional[HParamsSource]) -> None:
         )
         if hparams is None:
             hparams = f"auto:default:model={model};task={context.dataset.metadata.task.type.value};run_type=train"
-            logger.info(f"Hyperparameters are not provided, using default ones: '%s'.", hparams)
+            logger.info("Hyperparameters are not provided, using default ones: '%s'.", hparams)
 
         hp_dict: t.Dict = get_hparams(hparams)
         logger.info("Hyperparameters resolved to: '%s'", hp_dict)


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit introduces new tools (pyre + ruff) to lint and format the python code. Respectively, existing tools (Black, isort and flake8) are removed. The following is the list of commands that check the code and format it:
```shell
ruff format .
ruff check --fix .
pyre --search-path $(python -c 'import site; print(site.getsitepackages()[0])') check
```

In addition, the code has been updated to pass almost all pyre checks (this is still work in progress).

# What changes are proposed in this pull request?

- [x] Bug fix.
- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] If applicable, new and existing unit tests pass locally with my changes.

