### PR TITLE
Correct processing of `missing metric` case.

### DIFF
--- a/training/xtime/contrib/tune_ext.py
+++ b/training/xtime/contrib/tune_ext.py
@@ -119,7 +119,7 @@ class Analysis(object):
             if best_trial is not None:
                 best_params = IO.load_json((Path(best_trial.logdir) / "params.json").as_posix())
                 best_results = IO.load_json((Path(best_trial.logdir) / "result.json").as_posix())
-                best_results = {k: best_results[k] for k in perf_metrics}
+                best_results = {k: best_results[k] for k in perf_metrics if k in best_results}
                 summary["best_run"] = {"perf_metric": perf_metric, "parameters": best_params, "results": best_results}
 
             summary["metric_variations"] = {}
@@ -127,10 +127,11 @@ class Analysis(object):
                 succeeded_trials: pd.DataFrame = experiment.results_df[experiment.results_df[perf_metric].notna()]
                 results = succeeded_trials.sort_values([perf_metric], ascending=True)
                 for metric in perf_metrics:
-                    summary["metric_variations"][metric] = {
-                        "mean": results[metric].mean().item(),
-                        "std": results[metric].std().item(),
-                    }
+                    if metric in results.columns:
+                        summary["metric_variations"][metric] = {
+                            "mean": results[metric].mean().item(),
+                            "std": results[metric].std().item(),
+                        }
 
             summary["mlflow_run"] = mlflow_run_id
             return summary

--- a/training/xtime/stages/search_hp.py
+++ b/training/xtime/stages/search_hp.py
@@ -177,9 +177,18 @@ def _get_metrics_for_best_trial(results: ResultGrid, ctx: Context) -> t.Dict:
     metrics: t.Dict = copy.deepcopy(best_result.metrics or {})
 
     if ctx.dataset is not None:
-        missing_metrics: t.Set = {m for m in METRICS[ctx.dataset.metadata.task.type] if m not in metrics}
+        expected_metrics: t.List[str] = METRICS[ctx.dataset.metadata.task.type]
+        missing_metrics: t.Set = {m for m in expected_metrics if m not in metrics}
         if missing_metrics:
-            print(f"[WARNING] Missing metrics in the best trial: {missing_metrics}. Program may crash.")
+            logger.warning(
+                "Expected metrics not found in best trial (log_dir=%s): dataset=%s, task=%s, expected_metrics=%s, "
+                "missing_metrics=%s.",
+                best_result.log_dir,
+                ctx.dataset.metadata.name,
+                ctx.dataset.metadata.task.type,
+                expected_metrics,
+                missing_metrics,
+            )
 
     return metrics
 


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

A dataset that contains train and valid splits and that does not contain a test split causes errors in several places. This commit fixes by checking what metrics are present, and logging (summarizing) only those that present.


# What changes are proposed in this pull request?

- [x] Bug fix.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] If applicable, new and existing unit tests pass locally with my changes.

