### PR TITLE
Adding support for multiple parallel trials to use one GPU.

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -271,6 +271,19 @@ Other variables specific to some datasets:
   looks for proxy server using the following ordered list of environment variables: `https_proxy`, `HTTPS_PROXY`, 
   `http_proxy`, `HTTP_PROXY`. The fist non-empty value will be used.
 
+
+# GPU support
+Gradient boosting tree estimators (CatBoost, LightGBM and XGBoost) will use GPUs when `CUDA_VISIBLE_DEVICES` variable 
+is set.
+- `train` When running a training experiment, export `CUDA_VISIBLE_DEVICES` environment variable amd point to a single 
+  GPU to use.
+- `search_hp` When running hyperparameter optimization experiments, `CUDA_VISIBLE_DEVICES` can point to multiple devices
+  to be used by the Ray Tune trial scheduler. In addition, to use GPUs users must provide `--gpu` option. The value 
+  is a floating point number between 0 and 1 that defines how much GPU a single trial can potentially use. For instance,
+  with `--gpu 0.1` Ray Tune can schedule 10 parallel trials on a single GPU. When no value provided (`--gpu`), it is
+  automatically set to 1 (this is backward compatible with previous implementation when `--gpu` was a flag).
+
+
 # Using `xtime.training` as a project dependency
 This project can be specified as a dependency for a project using `poetry`:
 ```toml

--- a/training/xtime/main.py
+++ b/training/xtime/main.py
@@ -77,7 +77,7 @@ def _run_search_hp_pipeline(
     hparams: t.Optional[t.Tuple[str]],
     num_search_trials: int,
     num_validate_trials: int = 0,
-    gpu: bool = False,
+    gpu: float = 0,
 ) -> None:
     from xtime.stages.search_hp import search_hp
 
@@ -160,7 +160,11 @@ def experiment_train(dataset: str, model: str, params: t.Tuple[str]) -> None:
     default=0,
     help="Number of trials to retrain a model using the best configuration found with HPO.",
 )
-@click.option("--gpu", is_flag=True, help="Use GPUs (1 GPU per trial).")
+@click.option(
+    "--gpu", required=False, type=float, is_flag=False, default=0, flag_value=1,
+    help="A GPU fraction to use for a single trial (a number between 0 and 1). When 0, not GPUs will be used. When 1, "
+         "a single GPU will be exclusively used by a single trial."
+)
 def experiment_search_hp(
     dataset: str,
     model: str,
@@ -168,8 +172,11 @@ def experiment_search_hp(
     params: t.Tuple[str],
     num_search_trials: int,
     num_validate_trials: int = 0,
-    gpu: bool = False,
+    gpu: float = 0,
 ) -> None:
+    if not (0 <= gpu <= 1):
+        print("The `--gpu` option value must be a floating point value from [0, 1].")
+        exit(1)
     try:
         known_problems = dataset.split(sep=";")
         for _problem in known_problems:

--- a/training/xtime/stages/search_hp.py
+++ b/training/xtime/stages/search_hp.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 
 def search_hp(
-    dataset: str, model: str, algorithm: str, hparams: t.Optional[HParamsSource], num_trials: int, gpu: bool = False
+    dataset: str, model: str, algorithm: str, hparams: t.Optional[HParamsSource], num_trials: int, gpu: float = 0
 ) -> str:
     estimator: t.Type[Estimator] = get_estimator(model)
 
@@ -110,8 +110,8 @@ def search_hp(
         )
 
         objective_fn = tune.with_parameters(estimator.fit, ctx=ctx)
-        if gpu:
-            objective_fn = tune.with_resources(objective_fn, {"gpu": 1})
+        if gpu > 0:
+            objective_fn = tune.with_resources(objective_fn, {"gpu": gpu})
         tuner = tune.Tuner(objective_fn, param_space=param_space, tune_config=tune_config, run_config=run_config)
         results: ResultGrid = tuner.fit()
 


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit changes the meaning of the `--gpu` command line argument parameter. In current implementation, it is a flag. When set, the Ray Tune scheduler assigns one trial to one GPU. This commit changes it to be an option with value being a GPU fraction - numerical value between 0 and 1 - that defines how much GPU a trial can potentially consume.

- When not provided, no GPUs will be used.
- When no value provided (`--gpu`), the value is set to 1 (this is backward compatible with current implementation).
- In all other cases, Ray Tune will use this value for scheduling multiple trials in parallel on a single GPU. For instance, with `--gpu 0.1` ten parallel trials can be scheduled on each GPU.


# What changes are proposed in this pull request?

- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] If applicable, new and existing unit tests pass locally with my changes.
