### PR TITLE
Making validation sets optional for estimators.

### DIFF
--- a/training/xtime/errors.py
+++ b/training/xtime/errors.py
@@ -46,7 +46,7 @@ class ErrorCode:
     ESTIMATOR_MISSING_PREREQUISITES_ERROR = 101
     DATASET_ERROR = 150
     DATASET_MISSING_PREREQUISITES_ERROR = 151
-    DATASET_MISSING_TRAIN_EVAL_SPLITS_ERROR = 152
+    DATASET_MISSING_TRAIN_SPLIT_ERROR = 152
 
 
 class XTimeError(Exception):
@@ -86,11 +86,8 @@ class DatasetError(XTimeError):
         return error
 
     @classmethod
-    def missing_train_eval_splits(cls, dataset: str, train_split: t.Any, eval_split: t.Any) -> "DatasetError":
-        message: str = (
-            f"Missing train and/or eval split (dataset={dataset}, "
-            f"train_split_is_none={train_split is None}, eval_split_is_none={eval_split is None})."
-        )
+    def missing_train_split(cls, dataset: str) -> "DatasetError":
+        message: str = f"Missing train split (dataset={dataset})."
         error = DatasetError(message)
-        error._error_code = ErrorCode.DATASET_MISSING_TRAIN_EVAL_SPLITS_ERROR
+        error._error_code = ErrorCode.DATASET_MISSING_TRAIN_SPLIT_ERROR
         return error

--- a/training/xtime/estimators/_lightgbm.py
+++ b/training/xtime/estimators/_lightgbm.py
@@ -57,18 +57,21 @@ class LightGBMClassifierEstimator(Estimator):
         self.model.booster_.save_model(save_dir / "model.txt")
 
     def fit_model(self, dataset: Dataset, **kwargs) -> None:
-        train_split = dataset.split(DatasetSplit.TRAIN)
-        eval_split = dataset.split(DatasetSplit.EVAL_SPLITS)
-        if train_split is None or eval_split is None:
-            raise DatasetError.missing_train_eval_splits(dataset.metadata.name, train_split, eval_split)
-
         kwargs = copy.deepcopy(kwargs)
+
+        train_split = dataset.split(DatasetSplit.TRAIN)
+        if train_split is None:
+            raise DatasetError.missing_train_split(dataset.metadata.name)
+
         kwargs.update(
             {
-                "eval_set": [(eval_split.x, eval_split.y)],
                 "feature_name": dataset.metadata.feature_names(),
                 "categorical_feature": dataset.metadata.categorical_feature_names(),
             }
         )
+
+        eval_split = dataset.split(DatasetSplit.EVAL_SPLITS)
+        if eval_split is not None:
+            kwargs["eval_set"] = [(eval_split.x, eval_split.y)]
 
         self.model.fit(train_split.x, train_split.y, **kwargs)

--- a/training/xtime/estimators/_sklearn.py
+++ b/training/xtime/estimators/_sklearn.py
@@ -28,6 +28,8 @@ from .estimator import Estimator
 
 __all__ = ["DummyEstimator", "RandomForestEstimator"]
 
+from ..errors import DatasetError
+
 
 class ScikitLearnEstimator(Estimator):
     def __init__(self, params: t.Dict, dataset_metadata: DatasetMetadata, classifier_cls, regressor_cls) -> None:
@@ -42,7 +44,9 @@ class ScikitLearnEstimator(Estimator):
             pickle.dump(self.model, file)
 
     def fit_model(self, dataset: Dataset, **kwargs) -> None:
-        train_split = dataset.splits[DatasetSplit.TRAIN]
+        train_split = dataset.split(DatasetSplit.TRAIN)
+        if train_split is None:
+            raise DatasetError.missing_train_split(dataset.metadata.name)
         self.model.fit(train_split.x, train_split.y, **kwargs)
 
 

--- a/training/xtime/estimators/_xgboost.py
+++ b/training/xtime/estimators/_xgboost.py
@@ -92,13 +92,15 @@ class XGBoostEstimator(Estimator):
         self.model.set_params(early_stopping_rounds=kwargs.pop("early_stopping_rounds"))
 
         train_split = dataset.split(DatasetSplit.TRAIN)
-        eval_split = dataset.split(DatasetSplit.EVAL_SPLITS)
-        if train_split is None or eval_split is None:
-            raise DatasetError.missing_train_eval_splits(dataset.metadata.name, train_split, eval_split)
+        if train_split is None:
+            raise DatasetError.missing_train_split(dataset.metadata.name)
+        eval_set = [(train_split.x, train_split.y)]  # validation_0
 
+        eval_split = dataset.split(DatasetSplit.EVAL_SPLITS)
+        if eval_split is not None:
+            eval_set.append((eval_split.x, eval_split.y))  # validation_1
         kwargs.update(
-            #         validation_0                    validation_1
-            eval_set=[(train_split.x, train_split.y), (eval_split.x, eval_split.y)],
+            eval_set=eval_set,
             verbose=kwargs.get("verbose", False),
         )
         self.model.fit(train_split.x, train_split.y, **kwargs)


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

The xtime estimators (xgboost, lightgbm, catboost and sklearn) now check if validation split is present. If it is present, they use it as eval set. No exceptions are raised when datasets do not provide validation splits.

# What changes are proposed in this pull request?

- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] If applicable, new and existing unit tests pass locally with my changes.

