### PR TITLE
Support for single-precision datasets.

### DIFF
--- a/training/tests/datasets/test_churn_modelling.py
+++ b/training/tests/datasets/test_churn_modelling.py
@@ -33,7 +33,11 @@ class TestChurnModelling(DatasetTestCase):
 
     NAME = "churn_modelling"
     CLASS = ChurnModellingBuilder
-    DATASETS = [DatasetTestCase.standard("default", _PARAMS), DatasetTestCase.standard("numerical", _PARAMS)]
+    DATASETS = [
+        DatasetTestCase.standard("default", _PARAMS),
+        DatasetTestCase.standard("numerical", _PARAMS),
+        DatasetTestCase.standard("numerical32", _PARAMS),
+    ]
 
     def test_all(self) -> None:
         self._test_datasets()

--- a/training/tests/datasets/test_eye_movements.py
+++ b/training/tests/datasets/test_eye_movements.py
@@ -33,7 +33,11 @@ class TestEyeMovements(DatasetTestCase):
 
     NAME = "eye_movements"
     CLASS = EyeMovementsBuilder
-    DATASETS = [DatasetTestCase.standard("default", _PARAMS), DatasetTestCase.standard("numerical", _PARAMS)]
+    DATASETS = [
+        DatasetTestCase.standard("default", _PARAMS),
+        DatasetTestCase.standard("numerical", _PARAMS),
+        DatasetTestCase.standard("numerical32", _PARAMS),
+    ]
 
     def test_all(self) -> None:
         self._test_datasets()

--- a/training/tests/datasets/test_forest_cover_type.py
+++ b/training/tests/datasets/test_forest_cover_type.py
@@ -33,7 +33,11 @@ class TestForestCoverType(DatasetTestCase):
 
     NAME = "forest_cover_type"
     CLASS = ForestCoverTypeBuilder
-    DATASETS = [DatasetTestCase.standard("default", _PARAMS), DatasetTestCase.standard("numerical", _PARAMS)]
+    DATASETS = [
+        DatasetTestCase.standard("default", _PARAMS),
+        DatasetTestCase.standard("numerical", _PARAMS),
+        DatasetTestCase.standard("numerical32", _PARAMS),
+    ]
 
     def test_all(self) -> None:
         self._test_datasets()

--- a/training/tests/datasets/test_gas_concentrations.py
+++ b/training/tests/datasets/test_gas_concentrations.py
@@ -33,7 +33,11 @@ class TestGasConcentrations(DatasetTestCase):
 
     NAME = "gas_concentrations"
     CLASS = GasConcentrationsBuilder
-    DATASETS = [DatasetTestCase.standard("default", _PARAMS), DatasetTestCase.standard("numerical", _PARAMS)]
+    DATASETS = [
+        DatasetTestCase.standard("default", _PARAMS),
+        DatasetTestCase.standard("numerical", _PARAMS),
+        DatasetTestCase.standard("numerical32", _PARAMS),
+    ]
 
     def test_all(self) -> None:
         self._test_datasets()

--- a/training/tests/datasets/test_gesture_phase.py
+++ b/training/tests/datasets/test_gesture_phase.py
@@ -33,7 +33,11 @@ class TestGesturePhaseSegmentation(DatasetTestCase):
 
     NAME = "gesture_phase_segmentation"
     CLASS = GesturePhaseSegmentationBuilder
-    DATASETS = [DatasetTestCase.standard("default", _PARAMS), DatasetTestCase.standard("numerical", _PARAMS)]
+    DATASETS = [
+        DatasetTestCase.standard("default", _PARAMS),
+        DatasetTestCase.standard("numerical", _PARAMS),
+        DatasetTestCase.standard("numerical32", _PARAMS),
+    ]
 
     def test_all(self) -> None:
         self._test_datasets()

--- a/training/tests/datasets/test_rossmann_store_sales.py
+++ b/training/tests/datasets/test_rossmann_store_sales.py
@@ -33,7 +33,11 @@ class TestRossmannStoreSales(DatasetTestCase):
 
     NAME = "rossmann_store_sales"
     CLASS = RossmannStoreSalesBuilder
-    DATASETS = [DatasetTestCase.standard("default", _PARAMS), DatasetTestCase.standard("numerical", _PARAMS)]
+    DATASETS = [
+        DatasetTestCase.standard("default", _PARAMS),
+        DatasetTestCase.standard("numerical", _PARAMS),
+        DatasetTestCase.standard("numerical32", _PARAMS),
+    ]
 
     def test_all(self) -> None:
         self._test_datasets()

--- a/training/tests/datasets/test_telco_customer_churn.py
+++ b/training/tests/datasets/test_telco_customer_churn.py
@@ -33,7 +33,11 @@ class TestProblemChurnModelling(DatasetTestCase):
 
     NAME = "telco_customer_churn"
     CLASS = TelcoCustomerChurnBuilder
-    DATASETS = [DatasetTestCase.standard("default", _PARAMS), DatasetTestCase.standard("numerical", _PARAMS)]
+    DATASETS = [
+        DatasetTestCase.standard("default", _PARAMS),
+        DatasetTestCase.standard("numerical", _PARAMS),
+        DatasetTestCase.standard("numerical32", _PARAMS),
+    ]
 
     def test_all(self) -> None:
         self._test_datasets()

--- a/training/tests/datasets/test_year_prediction_msd.py
+++ b/training/tests/datasets/test_year_prediction_msd.py
@@ -33,7 +33,7 @@ class TestProblemChurnModelling(DatasetTestCase):
 
     NAME = "year_prediction_msd"
     CLASS = YearPredictionMSDBuilder
-    DATASETS = [DatasetTestCase.standard("default", _PARAMS)]
+    DATASETS = [DatasetTestCase.standard("default", _PARAMS), DatasetTestCase.standard("numerical32", _PARAMS)]
 
     def test_all(self) -> None:
         self._test_datasets()

--- a/training/xtime/datasets/_churn_modelling.py
+++ b/training/xtime/datasets/_churn_modelling.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-
+import functools
 import typing as t
 from pathlib import Path
 
@@ -43,7 +43,11 @@ class ChurnModellingBuilder(DatasetBuilder):
 
     def __init__(self, path: t.Optional[t.Union[str, Path]] = None, **kwargs) -> None:
         super().__init__()
-        self.builders.update(default=self._build_default_dataset, numerical=self._build_numerical_dataset)
+        self.builders.update(
+            default=self._build_default_dataset,
+            numerical=self._build_numerical_dataset,
+            numerical32=functools.partial(self._build_numerical_dataset, precision="single"),
+        )
         self.path: Path = IO.get_path(path, "~/.cache/kaggle/datasets/shrutime")
         self.file_name = kwargs.get("file_name", "Churn_Modelling.csv")
 

--- a/training/xtime/datasets/_eye_movements.py
+++ b/training/xtime/datasets/_eye_movements.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
+import functools
+
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
@@ -30,7 +32,11 @@ class EyeMovementsBuilder(DatasetBuilder):
 
     def __init__(self) -> None:
         super().__init__(openml=True)
-        self.builders.update(default=self._build_default_dataset, numerical=self._build_numerical_dataset)
+        self.builders.update(
+            default=self._build_default_dataset,
+            numerical=self._build_numerical_dataset,
+            numerical32=functools.partial(self._build_numerical_dataset, precision="single"),
+        )
 
     def _check_pre_requisites(self) -> None:
         DatasetPrerequisites.check_openml(self.NAME, "openml.org/d/1044")

--- a/training/xtime/datasets/_forest_cover_type.py
+++ b/training/xtime/datasets/_forest_cover_type.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-
+import functools
 from pathlib import Path
 
 import numpy as np
@@ -38,7 +38,11 @@ class ForestCoverTypeBuilder(DatasetBuilder):
 
     def __init__(self) -> None:
         super().__init__()
-        self.builders.update(default=self._build_default_dataset, numerical=self._build_numerical_dataset)
+        self.builders.update(
+            default=self._build_default_dataset,
+            numerical=self._build_numerical_dataset,
+            numerical32=functools.partial(self._build_numerical_dataset, precision="single"),
+        )
 
     def _build_default_dataset(self, **kwargs) -> Dataset:
         """Create `Forest Cover Type (cover_type)` train/valid/test datasets.

--- a/training/xtime/datasets/_gas_concentrations.py
+++ b/training/xtime/datasets/_gas_concentrations.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
+import functools
 
 import pandas as pd
 from sklearn.model_selection import train_test_split
@@ -30,7 +31,11 @@ class GasConcentrationsBuilder(DatasetBuilder):
 
     def __init__(self) -> None:
         super().__init__(openml=True)
-        self.builders.update(default=self._build_default_dataset, numerical=self._build_numerical_dataset)
+        self.builders.update(
+            default=self._build_default_dataset,
+            numerical=self._build_numerical_dataset,
+            numerical32=functools.partial(self._build_numerical_dataset, precision="single"),
+        )
 
     def _check_pre_requisites(self) -> None:
         DatasetPrerequisites.check_openml(self.NAME, "openml.org/d/1477")

--- a/training/xtime/datasets/_gesture_phase.py
+++ b/training/xtime/datasets/_gesture_phase.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
+import functools
 
 import pandas as pd
 from sklearn.model_selection import train_test_split
@@ -30,7 +31,11 @@ class GesturePhaseSegmentationBuilder(DatasetBuilder):
 
     def __init__(self) -> None:
         super().__init__(openml=True)
-        self.builders.update(default=self._build_default_dataset, numerical=self._build_numerical_dataset)
+        self.builders.update(
+            default=self._build_default_dataset,
+            numerical=self._build_numerical_dataset,
+            numerical32=functools.partial(self._build_numerical_dataset, precision="single"),
+        )
 
     def _check_pre_requisites(self) -> None:
         DatasetPrerequisites.check_openml(self.NAME, "openml.org/d/4538")

--- a/training/xtime/datasets/_rossmann_store_sales.py
+++ b/training/xtime/datasets/_rossmann_store_sales.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-
 import calendar
+import functools
 from pathlib import Path
 
 import numpy as np
@@ -36,7 +36,11 @@ class RossmannStoreSalesBuilder(DatasetBuilder):
 
     def __init__(self) -> None:
         super().__init__()
-        self.builders.update(default=self._build_default_dataset, numerical=self._build_numerical_dataset)
+        self.builders.update(
+            default=self._build_default_dataset,
+            numerical=self._build_numerical_dataset,
+            numerical32=functools.partial(self._build_numerical_dataset, precision="single"),
+        )
         self._data_dir = Path("~/.cache/kaggle/datasets/rossmann_store_sales").expanduser()
         self._train_file = "train.csv.gz"
         self._store_file = "store.csv.gz"

--- a/training/xtime/datasets/_telco_customer_churn.py
+++ b/training/xtime/datasets/_telco_customer_churn.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-
+import functools
 from pathlib import Path
 
 import pandas as pd
@@ -36,7 +36,11 @@ class TelcoCustomerChurnBuilder(DatasetBuilder):
 
     def __init__(self) -> None:
         super().__init__()
-        self.builders.update(default=self._build_default_dataset, numerical=self._build_numerical_dataset)
+        self.builders.update(
+            default=self._build_default_dataset,
+            numerical=self._build_numerical_dataset,
+            numerical32=functools.partial(self._build_numerical_dataset, precision="single"),
+        )
         self._data_dir = Path("~/.cache/kaggle/datasets/blastchar").expanduser()
         self._data_file = "WA_Fn-UseC_-Telco-Customer-Churn.csv"
 

--- a/training/xtime/datasets/_year_prediction_msd.py
+++ b/training/xtime/datasets/_year_prediction_msd.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-
+import functools
 import logging
 from pathlib import Path
 
@@ -34,7 +34,10 @@ class YearPredictionMSDBuilder(DatasetBuilder):
 
     def __init__(self) -> None:
         super().__init__()
-        self.builders.update(default=self._build_default_dataset)
+        self.builders.update(
+            default=self._build_default_dataset,
+            numerical32=functools.partial(self._build_numerical_dataset, precision="single"),
+        )
 
     def _build_default_dataset(self, **kwargs) -> Dataset:
         """


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit adds support from single-precision (float32) datasets. New dataset version (`numerical32`) is added. This is essentially the same as numerical, except that column types are converted to `np.float32` data type.

# What changes are proposed in this pull request?

- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, new and existing unit tests pass locally with my changes.

