### PR TITLE
Changing label types from int64 to int32.

### DIFF
--- a/training/xtime/datasets/_churn_modelling.py
+++ b/training/xtime/datasets/_churn_modelling.py
@@ -99,7 +99,10 @@ class ChurnModellingBuilder(DatasetBuilder):
                 # Drop unique columns ('RowNumber', 'CustomerId') and textual fields (second names - 'Surname')
                 ("drop_cols", DropColumns(["RowNumber", "CustomerId", "Surname"])),
                 # Convert several numerical columns to floating point format
-                ("change_cols_type", ChangeColumnsType(["CreditScore", "Age", "Tenure"], dtype=float)),
+                # Change feature data types
+                ("change_feature_types", ChangeColumnsType(["CreditScore", "Age", "Tenure"], dtype=float)),
+                # Change label data type
+                ("change_label_type", ChangeColumnsType([label], dtype="int32")),
                 # Check columns are in the right order
                 ("check_cols_order", CheckColumnsOrder([f.name for f in features], label=label)),
             ]

--- a/training/xtime/datasets/_eye_movements.py
+++ b/training/xtime/datasets/_eye_movements.py
@@ -77,7 +77,7 @@ class EyeMovementsBuilder(DatasetBuilder):
         assert isinstance(y, pd.Series), f"Expecting y to be of type pd.Series (type = {type(y)})."
 
         # Encode labels. Move from `category` type to int type with labels [0, 1, 2]
-        y = y.astype(int)
+        y = y.astype("int32")
 
         #
         _binary_features = ["P1stFixation", "P2stFixation", "nextWordRegress"]

--- a/training/xtime/datasets/_forest_cover_type.py
+++ b/training/xtime/datasets/_forest_cover_type.py
@@ -28,7 +28,7 @@ from sklearn.utils import Bunch
 from xtime.ml import ClassificationTask, Feature, FeatureType, TaskType
 
 from .dataset import Dataset, DatasetBuilder, DatasetMetadata, DatasetSplit
-from .preprocessing import ChangeColumnsTypeToCategory, CheckColumnsOrder
+from .preprocessing import ChangeColumnsType, ChangeColumnsTypeToCategory, CheckColumnsOrder
 
 __all__ = ["ForestCoverTypeBuilder"]
 
@@ -95,6 +95,8 @@ class ForestCoverTypeBuilder(DatasetBuilder):
                 ("check_cols_order", CheckColumnsOrder([f.name for f in features], label=label)),
                 # Update col types for binary features
                 ("set_category_type", ChangeColumnsTypeToCategory(features)),
+                # Change data type for the label column
+                ("change_label_type", ChangeColumnsType([label], dtype="int32")),
             ]
         )
         data = pipeline.fit_transform(data)

--- a/training/xtime/datasets/_gas_concentrations.py
+++ b/training/xtime/datasets/_gas_concentrations.py
@@ -73,7 +73,7 @@ class GasConcentrationsBuilder(DatasetBuilder):
         assert isinstance(y, pd.Series), f"Expecting y to be of type pd.Series (type = {type(y)})."
 
         # Encode labels (it's categorical column with values from [1, 6])
-        y = pd.Series(LabelEncoder().fit_transform(y), index=y.index, name=y.name)
+        y = pd.Series(LabelEncoder().fit_transform(y), index=y.index, name=y.name).astype("int32")
 
         # Remove instances with missing values
         # No need to remove instances with missing values - no such instances.

--- a/training/xtime/datasets/_gesture_phase.py
+++ b/training/xtime/datasets/_gesture_phase.py
@@ -76,7 +76,7 @@ class GesturePhaseSegmentationBuilder(DatasetBuilder):
         assert isinstance(y, pd.Series), f"Expecting y to be of type pd.Series (type = {type(y)})."
 
         # Encode labels
-        y = pd.Series(LabelEncoder().fit_transform(y), index=y.index, name=y.name)
+        y = pd.Series(LabelEncoder().fit_transform(y), index=y.index, name=y.name).astype("int32")
 
         # Remove instances with missing values
         # No need to remove instances with missing values - no such instances.

--- a/training/xtime/datasets/_telco_customer_churn.py
+++ b/training/xtime/datasets/_telco_customer_churn.py
@@ -24,7 +24,7 @@ from sklearn.preprocessing import LabelEncoder
 from xtime.ml import ClassificationTask, Feature, FeatureType, TaskType
 
 from .dataset import Dataset, DatasetBuilder, DatasetMetadata, DatasetSplit
-from .preprocessing import ChangeColumnsTypeToCategory, CheckColumnsOrder
+from .preprocessing import ChangeColumnsType, ChangeColumnsTypeToCategory, CheckColumnsOrder
 
 __all__ = ["TelcoCustomerChurnBuilder"]
 
@@ -128,6 +128,8 @@ class TelcoCustomerChurnBuilder(DatasetBuilder):
                 ("check_cols_order", CheckColumnsOrder([f.name for f in features], label=label)),
                 # Update col types for binary features
                 ("set_category_type", ChangeColumnsTypeToCategory(features)),
+                # Change label data type
+                ("change_label_type", ChangeColumnsType([label], dtype="int32")),
             ]
         )
         data = pipeline.fit_transform(data)

--- a/training/xtime/datasets/dataset.py
+++ b/training/xtime/datasets/dataset.py
@@ -148,6 +148,14 @@ class Dataset:
         if error_msg:
             raise ValueError(f"Invalid dataset specification. {error_msg}")
 
+        # Check labels have int32 data type
+        if self.metadata.task.type.classification():
+            for split_name, split_data in self.splits.items():
+                if split_data.y.dtype != np.int32:
+                    # TODO sergey: raise an exception once unit tests are added for all datasets.
+                    # raise ValueError(f"Labels in '{split_name}' split should have int32 data type.")
+                    logger.warning("Labels in '%s' split should have int32 data type.", split_name)
+
     def num_examples(self, split_names: t.Optional[t.Union[str, t.Iterable[str]]] = None) -> int:
         if not split_names:
             split_names = self.splits.keys()


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

For classification datasets that already have unit tests, the type of label series is changed from default (int64) to int32 (that is expected by most ML libraries). For datasets that do not have unit tests yet, this needs to be done in future commits.

# What changes are proposed in this pull request?

- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, new and existing unit tests pass locally with my changes.

