### PR TITLE
Fixing bugs in parsing hparams.

### DIFF
--- a/training/tests/hparams/test_hparams.py
+++ b/training/tests/hparams/test_hparams.py
@@ -40,3 +40,17 @@ class TestUtils(TestCase):
         self.assertIsInstance(value, hp.ValueSpec)
         self.assertIs(int, value.dtype)
         self.assertEqual(6, value.default)
+
+    def test_params_protocol(self) -> None:
+        self.assertDictEqual(
+            {"n_streams": 4, "n_estimators": 1, "n_trees": 1},
+            hp.from_string("params:n_streams=4;n_estimators=1;n_trees=1"),
+        )
+        self.assertDictEqual(
+            {"n_streams": 4, "n_estimators": 1, "n_trees": 1},
+            hp.from_string("params:;n_streams=4;n_estimators=1;n_trees=1;"),
+        )
+        with self.assertRaises(ValueError) as assert_raises_context:
+            _ = hp.from_string("n_streams=4;params:n_estimators=1;n_trees=1;")
+        msg = str(assert_raises_context.exception)
+        self.assertTrue(msg.endswith("Parameter name ('params:n_estimators') is not a valid identifier."))

--- a/training/xtime/hparams/_hparams.py
+++ b/training/xtime/hparams/_hparams.py
@@ -263,10 +263,26 @@ def from_string(params: t.Optional[str] = None) -> t.Dict:
     # Iterate over each parameter and parse it.
     hp_dict = {}
     for idx, param in enumerate(params.split(";")):
+        # Check of this is an empty spec (e.g., `;` at the end such as "params:lr=0.3;batch=128;")
+        param = param.strip()
+        if not param:
+            continue
+        #
         try:
-            name, value = param.split("=")
+            name, value = param.split("=", maxsplit=1)
         except ValueError as err:
-            raise ValueError(f"Invalid parameter in from_list (params={params}, idx={idx}, param={param}).") from err
+            raise ValueError(
+                f"Invalid parameter in from_string (params={params}, idx={idx}, param={param}). Cannot split parameter "
+                "spec (using '=' character) into parameter name and parameter value."
+            ) from err
+
+        name = name.strip()
+        if not name.isidentifier():
+            raise ValueError(
+                f"Invalid parameter in from_string (params={params}, idx={idx}, param={param}). "
+                f"Parameter name ('{name}') is not a valid identifier."
+            )
+        #
         try:
             # Try to evaluate the value, if failed, use as is its string value. Maybe confusing, but simplifies
             # providing string values, e.g., model=xgboost instead of model='xgboost'.


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Two bugs are fixed in this commit:
- Empty parameter specs are ignored. This is caused by adding one or several `;` at the end of the specification string, e.g., "params:;n_streams=4;n_estimators=1;n_trees=1;".
- Raising an error if parased parameter name is not a valid python identifier. This can happen when accidently a parameter is placed in front on the protocol spec, e.g., "n_streams=4;params:n_estimators=1;n_trees=1;". In this case, parameter name "params:n_estimators" is not a valid identifier.

# What changes are proposed in this pull request?

- [x] Bug fix.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, new and existing unit tests pass locally with my changes.

