### PR TITLE
Ray dashboards listen on all available interfaces (0.0.0.0).

### DIFF
--- a/training/xtime/stages/search_hp.py
+++ b/training/xtime/stages/search_hp.py
@@ -56,7 +56,7 @@ def search_hp(
 ) -> str:
     estimator: t.Type[Estimator] = get_estimator(model)
 
-    ray.init()
+    ray.init(include_dashboard=True, dashboard_host="0.0.0.0")
     ray_tune_extensions.add_representers()
     MLflow.create_experiment()
     with mlflow.start_run(description=" ".join(sys.argv)) as active_run:


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit makes ray dashboards listen on all available interfaces (0.0.0.0) so that they are accesible from remote machines. This applies to hyperparameter search runs (`search_hp`).

# What changes are proposed in this pull request?

- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] If applicable, new and existing unit tests pass locally with my changes.

