### PR TITLE
Pre-loading dataset for hyperparameter search.

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -270,7 +270,10 @@ Other variables specific to some datasets:
   more details). Usage example: `export XTIME_DISABLE_PATCH_MINIO=1`. When this patching is not disabled, the `xtime`
   looks for proxy server using the following ordered list of environment variables: `https_proxy`, `HTTPS_PROXY`, 
   `http_proxy`, `HTTP_PROXY`. The fist non-empty value will be used.
-
+- `XTIME_SEARCH_HP_PRE_LOAD_DATASET` When running hyperparameter search experiments (`search_hp`), it is possible to 
+  preload the dataset before starting the search. Ray object store is used to distributed the dataset to workers.  
+  Usage example: `export XTIME_SEARCH_HP_PRE_LOAD_DATASET=1`.
+  
 
 # GPU support
 Gradient boosting tree estimators (CatBoost, LightGBM and XGBoost) will use GPUs when `CUDA_VISIBLE_DEVICES` variable 

--- a/training/xtime/estimators/estimator.py
+++ b/training/xtime/estimators/estimator.py
@@ -187,6 +187,8 @@ class Estimator:
         """
         if ctx.dataset is None:
             ctx.dataset = Dataset.create(ctx.metadata.dataset)
+        else:
+            logger.info("Not loading dataset - it has already been loaded.")
         dataset: Dataset = ctx.dataset
 
         if ctx.callbacks:

--- a/training/xtime/stages/search_hp.py
+++ b/training/xtime/stages/search_hp.py
@@ -78,6 +78,9 @@ def search_hp(
         run_id: str = active_run.info.run_id
 
         ctx = Context(Metadata(dataset=dataset, model=model, run_type=RunType.HPO), dataset=Dataset.create(dataset))
+        if os.environ.get("XTIME_SEARCH_HP_PRE_LOAD_DATASET", 0) == "1":
+            logger.info("RayTuneDriver: pre-loading dataset (will use Ray Tune object store).")
+            ctx.dataset = Dataset.create(ctx.metadata.dataset)
 
         fit_params = fit_params or ""
         if fit_params:


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Users can now set `XTIME_SEARCH_HP_PRE_LOAD_DATASET` environment variable to 1 to instruct the `search_hp` stage to load the dataset in advance and distribute it to worker processes via ray object store.

# What changes are proposed in this pull request?

- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] If applicable, new and existing unit tests pass locally with my changes.

