### PR TITLE
`Library not installed` warning message for estimators.

### DIFF
--- a/training/xtime/errors.py
+++ b/training/xtime/errors.py
@@ -74,6 +74,16 @@ class EstimatorError(XTimeError):
         error._error_code = ErrorCode.ESTIMATOR_MISSING_PREREQUISITES_ERROR
         return error
 
+    @classmethod
+    def library_not_installed(cls, estimator: str, library: str, dep_groups: t.List[str]) -> "EstimatorError":
+        return EstimatorError.missing_prerequisites(
+            f"{estimator} estimator is not available because `{library}` library is not installed. "
+            f"This library is optional in XTIME and should be installed by specifying one of the following optional "
+            f"(extra) dependencies: `{dep_groups}` (select the one suitable for your system). "
+            f"Poetry example: `poetry install --extras {dep_groups[0]}`. More details are here: "
+            "https://github.com/HewlettPackard/X-TIME/tree/main/training."
+        )
+
 
 class DatasetError(XTimeError):
     def __init__(self, message: str) -> None:

--- a/training/xtime/estimators/_catboost.py
+++ b/training/xtime/estimators/_catboost.py
@@ -18,15 +18,14 @@ import copy
 import typing as t
 from pathlib import Path
 
+from xtime.errors import DatasetError
+
 try:
     import catboost as cb
 except ImportError:
-    from xtime.errors import DatasetError, EstimatorError
+    from xtime.errors import EstimatorError
 
-    raise EstimatorError.missing_prerequisites(
-        "CatBoost estimator is not available because `catboost` library is not installed. This library is optional in "
-        "this project and should be installed by specifying the `catboost` optional (extra) dependency."
-    )
+    raise EstimatorError.library_not_installed("CatboostEstimator", "catboost", ["catboost"])
 
 from xtime.contrib.tune_ext import gpu_available
 from xtime.datasets import Dataset, DatasetMetadata, DatasetSplit
@@ -34,6 +33,8 @@ from xtime.io import IO
 from xtime.ml import TaskType
 
 from .estimator import Estimator
+
+__all__ = ["CatboostEstimator"]
 
 
 class CatboostEstimator(Estimator):

--- a/training/xtime/estimators/_lightgbm.py
+++ b/training/xtime/estimators/_lightgbm.py
@@ -18,7 +18,12 @@ import copy
 import typing as t
 from pathlib import Path
 
-from lightgbm.sklearn import LGBMClassifier, LGBMModel, LGBMRegressor
+try:
+    from lightgbm.sklearn import LGBMClassifier, LGBMModel, LGBMRegressor
+except ImportError:
+    from xtime.errors import EstimatorError
+
+    raise EstimatorError.library_not_installed("LightGBMClassifierEstimator", "lightgbm", ["lightgbm"])
 
 from xtime.contrib.tune_ext import gpu_available
 from xtime.datasets import Dataset, DatasetMetadata, DatasetSplit
@@ -26,6 +31,8 @@ from xtime.ml import ClassificationTask, TaskType
 
 from ..errors import DatasetError
 from .estimator import Estimator
+
+__all__ = ["LightGBMClassifierEstimator"]
 
 
 class LightGBMClassifierEstimator(Estimator):

--- a/training/xtime/estimators/_rapids.py
+++ b/training/xtime/estimators/_rapids.py
@@ -20,8 +20,14 @@ import typing as t
 from pathlib import Path
 
 import pandas as pd
-from cuml.ensemble import RandomForestClassifier, RandomForestRegressor
-from cuml.ensemble.randomforest_common import BaseRandomForestModel
+
+try:
+    from cuml.ensemble import RandomForestClassifier, RandomForestRegressor
+    from cuml.ensemble.randomforest_common import BaseRandomForestModel
+except ImportError:
+    from xtime.errors import EstimatorError
+
+    raise EstimatorError.library_not_installed("RandomForestEstimator", "cuml", ["rapids-12"])
 
 from xtime.datasets import Dataset, DatasetMetadata, DatasetSplit
 from xtime.errors import DatasetError

--- a/training/xtime/estimators/_xgboost.py
+++ b/training/xtime/estimators/_xgboost.py
@@ -18,7 +18,12 @@ import logging
 import typing as t
 from pathlib import Path
 
-from xgboost.sklearn import XGBClassifier, XGBModel, XGBRegressor
+try:
+    from xgboost.sklearn import XGBClassifier, XGBModel, XGBRegressor
+except ImportError:
+    from xtime.errors import EstimatorError
+
+    raise EstimatorError.library_not_installed("XGBoostEstimator", "xgboost", ["xgboost"])
 
 from xtime.contrib.tune_ext import gpu_available
 from xtime.datasets import Dataset, DatasetMetadata, DatasetSplit
@@ -26,6 +31,8 @@ from xtime.ml import TaskType
 
 from ..errors import DatasetError
 from .estimator import Estimator
+
+__all__ = ["XGBoostEstimator"]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Starting from this commit, all estimator implementations raise the `EstimatorError` error (with the help of `library_not_installed` class method) informing that an estimator is not available due to missing optional dependencies. The XTIME prints out this information at a warning level.

# What changes are proposed in this pull request?

- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] If applicable, new and existing unit tests pass locally with my changes.

