### PR TITLE
Setuptools version constraints for python < 3.11.

### DIFF
--- a/training/poetry.lock
+++ b/training/poetry.lock
@@ -6578,4 +6578,4 @@ xgboost = ["xgboost"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "a7230d5aeb788322a5059537ac0d9a4ff3d00090349a1cfbcec1f3bd5a67dd64"
+content-hash = "b13d5b1730c4d6d70271b7fc394e595b359909bf2f96a3849c9672ba12487327"

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -15,6 +15,11 @@ ray = [                     # core dependency
     { version = "2.3.1", extras = ["tune", "default"], python = "<3.11" },
     { version = "2.9.0", extras = ["tune", "default"], python = ">=3.11" }
 ]
+# Older versions of ray are not compatible with the latest versions of `setuptools`.
+# ImportError: cannot import name 'packaging' from 'pkg_resources'.
+# https://stackoverflow.com/questions/78604018/importerror-cannot-import-name-packaging-from-pkg-resources-when-trying-to
+setuptools = {version = "<70.0", python = "<3.11"}
+
 numpy = [                   # core dependency
     { version = "1.23.5", python = "<3.12" }
 ]


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Older version of Ray that this project uses (`2.3.1` for python < `3.11`) are not compatible with the latest versions of the `setuptools` package (`ImportError: cannot import name 'packaging' from 'pkg_resources'`). The solution described [here](https://stackoverflow.com/questions/78604018/importerror-cannot-import-name-packaging-from-pkg-resources-when-trying-to)  is to use earlier version (s). This commit introduces a constraint for the `setuptools` package for python versions < `3.11` where there's a conflict with Ray.

# What changes are proposed in this pull request?

- [x] Bug fix.


# Checklist:

- [x] I have commented my code.
- [x] If applicable, new and existing unit tests pass locally with my changes.

