### PR TITLE
Dynamic versioning for the training project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ run_context.yaml
 dist/
 .pyre/
 
+# Dynamic versioning
+training/xtime/_version.py
+
 # cycle_accurate folder
 ## autogen.sh
 cycle_accurate/src/libltdl/

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -1,10 +1,11 @@
 [tool.poetry]
 name = "xtime-training"
-version = "0.1.0"
+version = "0.0.0-post.92+8f0ea3e.dirty"
 description = ""
 authors = ["Hewlett Packard Labs"]
 readme = "README.md"
 packages = [{include = "xtime"}]
+include = ["xtime/_version.py"]     # https://python-poetry.org/docs/pyproject/#include-and-exclude
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"      # With `^3.9` dependency resolution fails.
@@ -112,6 +113,23 @@ markers = [
     "cli: marks tests as Command Line Interface (CLI) unit tests (deselect with '-m \"not cli\"')"
 ]
 
+[tool.poetry-dynamic-versioning]
+enable = true
+pattern-prefix = "training-"  # Tags should be `training-v0.1.0`, `training-v0.1.0-rc.1` etc.
+dirty = true
+ignore-untracked = true
+style = "semver"
+
+# sergey Is this really needed? When installing, the version info is available via package metadata. During development,
+# it can be infferred automaticalyl by looking at git history and project details. This can probably be useful when this
+# project is used as is (without installing it) by adjusting python paths?
+[tool.poetry-dynamic-versioning.files."xtime/_version.py"]
+persistent-substitution = true
+initial-content = """
+  # These version placeholders will be replaced later during substitution.
+  __version__ = "0.0.0"
+"""
+
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"  # This is a thin wrapper around `poetry.core.masonry.api`.

--- a/training/tests/test_version.py
+++ b/training/tests/test_version.py
@@ -1,0 +1,24 @@
+###
+# Copyright (2023) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+from unittest import TestCase
+
+
+class TestVersion(TestCase):
+    def test_version(self) -> None:
+        from xtime import __version__
+
+        self.assertIsInstance(__version__, str, f"Invalid __version__ type ({type(__version__)}).")
+        self.assertFalse(__version__ == "none", "The __version__ value must not be 'none'.")

--- a/training/xtime/__init__.py
+++ b/training/xtime/__init__.py
@@ -13,3 +13,75 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
+
+__version__ = None
+"""XTIME training version."""
+
+
+def _get_version() -> str:
+    """Identify the XTIME training package version."""
+    #
+    import importlib.metadata
+    import logging
+    from pathlib import Path
+
+    #
+    logger = logging.getLogger(__file__)
+
+    # If this is a development environment, try to get the version from the pyproject.toml and Git history. This is
+    # the "single source of truth". In order this to work, the poetry with poetry_dynamic_versioning plugin must be
+    # installed.
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    if pyproject_path.is_file():
+        try:
+            import os
+
+            import tomlkit
+            from poetry_dynamic_versioning import _get_config, _get_version
+
+            pyproject = tomlkit.parse(pyproject_path.read_bytes().decode("utf-8"))
+            config = _get_config(pyproject)
+
+            initial_dir = Path.cwd()
+            os.chdir(pyproject_path.parent.as_posix())
+            try:
+                version, _ = _get_version(config, name=pyproject["tool"]["poetry"]["name"])
+                logger.debug("Found version (%s) via poetry_dynamic_versioning.", version)
+                return version
+            finally:
+                os.chdir(initial_dir.as_posix())
+        except (ImportError, RuntimeError) as err:
+            # Will also catch ModuleNotFound
+            logger.debug(f"Failed to get version via poetry_dynamic_versioning module: {err}")
+    else:
+        logger.debug(
+            "Failed to get version via poetry_dynamic_versioning module. The pyproject.toml file (%s) not found",
+            pyproject_path.as_posix(),
+        )
+
+    # If this package has been installed, try to get its version from package metadata.
+    try:
+        version = importlib.metadata.version("xtime-training")
+        logger.debug("Found version (%s) via importlib (project installed?).", version)
+        return version
+    except importlib.metadata.PackageNotFoundError:
+        logger.debug("Failed to get version via importlib (project not installed?).")
+
+    # Try `xtime/_version.py` file. Is this needed? Probably, when this package is used as is (no install) by adjusting
+    # python paths.
+    version_py_file = Path(__file__).parent / "_version.py"
+    if version_py_file.is_file():
+        with open(version_py_file, "rt") as stream:
+            version = stream.read().strip()
+        if version:
+            logger.debug("Found version (%s) in _version.py file (%s).", version, version_py_file.as_posix())
+            return version
+        logger.debug("Found empty version (%s) in _version.py file (%s).", version, version_py_file.as_posix())
+    else:
+        logger.debug("Failed to get version in _version.py file (file not found).")
+
+    return "none"
+
+
+if __version__ is None:
+    __version__ = _get_version()


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit adds dynamic versioning feature for the `training` project. It is based on dynamic versioning plugin for Poetry (https://github.com/mtkennerly/poetry-dynamic-versioning). To install it, run:
```bash
poetry self add "poetry-dynamic-versioning[plugin]"
poetry version
```

- A new `xtime.__version__` variable is added that is computed on the fly:
  - First, try poetry dynamic versioning pluging to determine the project version. Useful for development.
  - Then, try project metadata. Works when package is installed.
  - In addition, a new file `xtime/_version.py` is generated (that becomes part of binary and source distributions) that is tested.
- The `poetry build` command produces versioned wheel and source distribution.
- Nox tests work too.
- This plugin relies on Git tags. The tags should be like `training-v0.1.0`, `training-v0.1.0-rc.1` etc. The `training-` prefix is removed.

# What changes are proposed in this pull request?

- [x] New feature.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, new and existing unit tests pass locally with my changes.

