### PR TITLE
Resetting project version in pyproject.toml.

### DIFF
--- a/training/noxfile.py
+++ b/training/noxfile.py
@@ -19,6 +19,7 @@ import typing as t
 from pathlib import Path
 
 import nox
+import tomlkit
 
 XTIME_NOX_PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
 """The list of python versions to run nox sessions with. Can be overridden by setting the environment variable."""
@@ -66,3 +67,12 @@ def unit_tests(session: nox.Session, deps: str) -> None:
 
     session.install(*install_args)
     session.run("pytest", "-v", *session.posargs)
+
+
+@nox.session()
+def test_pyproject_toml(session: nox.Session) -> None:
+    """Run various checks on pyproject.toml."""
+    pyproject = tomlkit.parse((Path(__file__).parent / "pyproject.toml").read_bytes().decode("utf-8"))
+    version = pyproject["tool"]["poetry"]["version"]
+    if version != "0.0.0":
+        raise ValueError(f"Invalid project version ({version}). Expected value is '0.0.0'.")

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xtime-training"
-version = "0.0.0-post.92+8f0ea3e.dirty"
+version = "0.0.0"
 description = ""
 authors = ["Hewlett Packard Labs"]
 readme = "README.md"

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -1,5 +1,7 @@
 [tool.poetry]
 name = "xtime-training"
+# This is a "placeholder" version - do not change. Actual version is set / determined by poetry dynamic versioning
+# plugin on the fly. Also see `xtime.__version__` variable in `xtime.__init__`.
 version = "0.0.0"
 description = ""
 authors = ["Hewlett Packard Labs"]


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Setting back project version in `pyproject.toml` to its placeholder value - `0.0.0` (actual version is computed by the poetry dynamic versioning plugin on the fly).
- Adding description in `pyproject.toml` explaining this is a placeholder version.
- Adding `nox` test to check the value of the version parameter.

# What changes are proposed in this pull request?

- [x] Bug fix.

# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, new and existing unit tests pass locally with my changes.
