### PR TITLE
Nox test for the train stage.

### DIFF
--- a/training/noxfile.py
+++ b/training/noxfile.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 ###
 
+import inspect
 import os
 import typing as t
 from pathlib import Path
@@ -75,9 +76,155 @@ def unit_tests(session: nox.Session, deps: str) -> None:
 
 
 @nox.session()
+@nox.parametrize("model", ["xgboost", "catboost", "lightgbm"])
+def model_train_test(session: nox.Session, model: str) -> None:
+    """Train a model and validate the output of the training stage.
+
+    Command to describe a dataset:
+        `python -m xtime.main dataset describe churn_modelling:default`
+    Command to run a training session:
+        `python -m xtime.main experiment train --params="params:n_estimators=10;random_state=1" dataset model`.
+
+    Args:
+        session: Current nox session.
+        model: Model to use. This must be a name for model's extra dependency (see
+            pyproject.toml -> [tool.poetry.extras] table). It is assumed that this name is the same as model name that
+            users provide on a command line (this is true for `catboost`, `xgboost` and `lightgbm`).
+    """
+    # Run the training session.
+    dataset: str = "churn_modelling:default"  # We will be using this dataset
+    session.install(f".[{model}]")  # Install only one extra dependency - xgboost
+    # Just in case - make sure the dataset is available
+    # session.run("python", "-m", "xtime.main", "dataset", "describe", dataset)
+    # We will use file system based MLflow backend
+    session_tmp_dir = Path(session.create_tmp()).resolve()
+
+    mlflow_uri: Path = session_tmp_dir / ".mlruns"
+    env_vars = {"MLFLOW_TRACKING_URI": mlflow_uri.as_uri(), "MLFLOW_EXPERIMENT_NAME": f"test_{model}"}
+
+    session.run(
+        "python",
+        "-m",
+        "xtime.main",
+        "experiment",
+        "train",
+        "--params=params:n_estimators=100;random_state=1",
+        dataset,
+        model,
+        env=env_vars,
+    )
+
+    # Validate output files
+    validate_file = session_tmp_dir / "validate.py"
+    with open(validate_file, "wt") as f:
+        validate_train_run_source: str = inspect.getsource(_validate_train_run)
+        f.write(validate_train_run_source)
+        f.write("\n_validate_train_run()\n")
+
+    session.run("python", validate_file.as_posix(), env=env_vars)
+
+
+@nox.session()
 def test_pyproject_toml(session: nox.Session) -> None:
     """Run various checks on pyproject.toml."""
     pyproject = tomlkit.parse((Path(__file__).parent / "pyproject.toml").read_bytes().decode("utf-8"))
     version = pyproject["tool"]["poetry"]["version"]
     if version != "0.0.0":
         raise ValueError(f"Invalid project version ({version}). Expected value is '0.0.0'.")
+
+
+def _validate_train_run() -> None:
+    """Validate `xtime.training` train run.
+
+    The test driver will get the source of this function and will write it into a file. Then, it will execute it
+    in the session python runtime. In current implementation, this function must be self-contained, e.g., keep all
+    imports needed by this function in the function body.
+
+    This function uses mlflow and xtime API. It validates the presence of MLflow runs and output artifacts (and content
+    of these artifacts to some extent). This function does not use ray tune API.
+    """
+    import os
+    import typing as t  # noqa
+
+    import mlflow
+    from mlflow.entities import Experiment, Run
+
+    from xtime.contrib.mlflow_ext import MLflow
+    from xtime.estimators.estimator import LegacySavedModelInfo, LegacySavedModelLoader
+    from xtime.io import IO
+
+    n = 10  # number of validation steps
+
+    experiment_name = os.environ["MLFLOW_EXPERIMENT_NAME"]  # test_MODEL
+    model_name = experiment_name[5:]
+    print(f"[validate_train_run] 00/{n} start validation experiment={experiment_name}, model={model_name}.")
+
+    # There must be one experiment.
+    experiment_ids: t.List[str] = MLflow.get_experiment_ids()
+    if len(experiment_ids) != 2:
+        raise ValueError(f"Expected two experiments (Default and {experiment_name}), but got {len(experiment_ids)}.")
+    for experiment_id in experiment_ids:
+        experiment: Experiment = mlflow.get_experiment(experiment_id)
+        if experiment.name not in {"Default", experiment_name}:
+            raise ValueError(f"Unexpected experiment name: {experiment.name}.")
+    print(f"[validate_train_run] 01/{n} experiments validated experiment_ids={experiment_ids}.")
+
+    # There must be one run
+    runs: t.List[Run] = MLflow.get_runs()
+    if len(runs) != 1:
+        raise ValueError(f"Expected one run, but got {len(runs)}.")
+    print(f"[validate_train_run] 02/{n} runs validated run_ids=[{runs[0].info.run_id}].")
+
+    # Verify run outputs
+    run: Run = runs[0]
+
+    artifact_path: Path = MLflow.get_artifact_path(run, ensure_exists=False)
+    if not artifact_path.is_dir():
+        raise ValueError(f"Run artifact path ({artifact_path}) does not exist or not directory.")
+    print(f"[validate_train_run] 03/{n} artifact path validated artifact_path={artifact_path.as_posix()}.")
+
+    saved_model_info = LegacySavedModelInfo.from_path(artifact_path)
+    expected_files = ["data_info.yaml", "model_info.yaml", "run_info.yaml", "run_inputs.yaml", "test_info.yaml"] + [
+        saved_model_info.file_name()
+    ]
+
+    missing_files = [f for f in expected_files if not (artifact_path / f).is_file()]
+    if missing_files:
+        raise ValueError(f"Missing files in the run artifact path: {missing_files}.")
+    print(f"[validate_train_run] 04/{n} files presence validated expected_files={expected_files}.")
+
+    _ = IO.load_dict(
+        artifact_path / "data_info.yaml", expected_keys={"features", "name", "properties", "task", "version"}
+    )
+    print(f"[validate_train_run] 05/{n} data_info.yaml validated.")
+
+    model_info = IO.load_dict(artifact_path / "model_info.yaml", expected_keys={"model"})
+    if model_info["model"]["name"] != model_name:
+        raise ValueError(f"Invalid model info: {model_info}.")
+    print(f"[validate_train_run] 06/{n} model_info.yaml validated.")
+
+    _ = IO.load_dict(
+        artifact_path / "run_info.yaml", expected_keys={"context", "env", "estimator", "hparams", "metadata"}
+    )
+    print(f"[validate_train_run] 07/{n} run_info.yaml validated.")
+
+    run_inputs = IO.load_dict(artifact_path / "run_inputs.yaml", expected_keys={"dataset", "hparams", "model"})
+    if run_inputs["model"] != model_name:
+        raise ValueError(f"Invalid run inputs: {model_info}.")
+    print(f"[validate_train_run] 08/{n} run_inputs.yaml validated.")
+
+    _ = IO.load_dict(
+        artifact_path / "test_info.yaml",
+        expected_keys={
+            "dataset_accuracy", "dataset_loss_mean", "dataset_loss_total", "test_accuracy", "test_auc", "test_f1",
+            "test_loss_mean", "test_loss_total", "test_precision", "test_recall", "train_accuracy", "train_auc",
+            "train_f1", "train_loss_mean", "train_loss_total", "train_precision", "train_recall", "valid_accuracy",
+            "valid_loss_mean", "valid_loss_total"
+        }
+    )  # fmt: skip
+    print(f"[validate_train_run] 09/{n} test_info.yaml validated.")
+
+    model = LegacySavedModelLoader.load_model(artifact_path, saved_model_info)
+    if model is None:
+        raise ValueError("Failed to load the model.")
+    print(f"[validate_train_run] 10/{n} model validated.")


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit adds a new test session that invokes xtime's train stage and then validates its outputs. Three models can be used with this test - `xgboost`, `catboost` and `lighgbm`:
```bash
nox -l

nox -s "model_train_test(model='xgboost')"
nox -s "model_train_test(model='catboost')"
nox -s "model_train_test(model='lightgbm')"
```

# What changes are proposed in this pull request?

- [x] New tests


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, new and existing unit tests pass locally with my changes.

