### PR TITLE
Updating `search_hp` stage to "support" NOX tests.

### DIFF
--- a/training/xtime/stages/search_hp.py
+++ b/training/xtime/stages/search_hp.py
@@ -56,7 +56,14 @@ def search_hp(
 ) -> str:
     estimator: t.Type[Estimator] = get_estimator(model)
 
-    ray.init(include_dashboard=True, dashboard_host="0.0.0.0")
+    ray_init_params = {"include_dashboard": True, "dashboard_host": "0.0.0.0"}
+    if "XTIME_NOX_TEST" in os.environ:
+        # FIXME: When running this as part of NOX tests, the following exception is raised: "OSError: AF_UNIX path
+        #        length cannot exceed 107 bytes". Does not work for Windows (https://github.com/ray-project/ray/issues/7724)
+        #
+        ray_init_params = {"_temp_dir": "/tmp/ray"}
+    ray.init(**ray_init_params)
+
     ray_tune_extensions.add_representers()
     MLflow.create_experiment()
     with mlflow.start_run(description=" ".join(sys.argv)) as active_run:


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Nox tests run in isolated python environments, and file system paths to these environments maybe quite long. Nox sessions have their own temp directories that are located inside python environments. Ray raises the following error "OSError: AF_UNIX path length cannot exceed 107 bytes". This commit fixes it by introducing an environment variable that is set in NOX environments. In this case, the `search_hp` stage instructs to use the host `/tmp/ray` as ray's temporary directory.

# What changes are proposed in this pull request?

- [x] Bug fix.


# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] If applicable, new and existing unit tests pass locally with my changes.

