### PR TITLE
Precision recall curve metric for binary classifiers.

### DIFF
--- a/training/xtime/errors.py
+++ b/training/xtime/errors.py
@@ -13,11 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
+import functools
 import logging
 import typing as t
 
 __all__ = [
     "maybe_suggest_debug_level",
+    "ignore_exceptions",
     "ErrorCode",
     "XTimeError",
     "ConfigurationError",
@@ -37,6 +39,30 @@ def maybe_suggest_debug_level(logger: t.Optional[logging.Logger] = None, prefix:
 
 def exception_if_debug(error: Exception, logger: logging.Logger) -> t.Optional[Exception]:
     return error if logger.isEnabledFor(logging.DEBUG) else None
+
+
+def ignore_exceptions(default_value: t.Any = None):
+    """Function decorator that can be used to supress all exceptions raised by the decorated function.
+
+    Args:
+        default_value: The value to return when an exception is caught.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except Exception as e:
+                logging.error(
+                    f"Exception occurred in {func.__name__}: {e}. It was caught by the `ignore_exceptions` function "
+                    "decorator. This exception will be ignored."
+                )
+                return default_value
+
+        return wrapper
+
+    return decorator
 
 
 class ErrorCode:


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

This commit adds a new performance metric - precision recall (PR) curve. It works for binary classification models. It is serialized as two files:
 - Yaml file containing precision, recall and threshold arrays that were used to build the PR curve.
 - Image (png) file that is graphical representation of the curve with threshold-recall curve on the same chart. The function that computes PR curve is decorated with a function decorator that ignores any exceptions raised during the process of computing the curve. This decorator (ignore_exceptions) is also part of this commit and can be used for other functions too.

# What changes are proposed in this pull request?

- [x] New feature.

# Checklist:

Select all that apply, and delete the others. If these changes are for `xtime.training`, please make sure to
provide unit tests and/or nox tests for bug fixes and new features.

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] If applicable, new and existing unit tests pass locally with my changes.

