### PR TITLE
Configure MLflow run name.

### DIFF
--- a/training/tests/contrib/test_mlflow_ext.py
+++ b/training/tests/contrib/test_mlflow_ext.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-from unittest import TestCase
+import os
+from unittest import TestCase, mock
 
 from xtime.contrib.mlflow_ext import MLflow
 
@@ -26,3 +27,12 @@ class TestMLflow(TestCase):
         self.assertEqual(run_id, MLflow.get_run_id(f"mlflow:{run_id}"))
         self.assertEqual(run_id, MLflow.get_run_id(f"mlflow:/{run_id}"))
         self.assertEqual(run_id, MLflow.get_run_id(f"mlflow:///{run_id}"))
+
+    @mock.patch.dict(os.environ)
+    def test_get_run_name_none(self) -> None:
+        _ = os.environ.pop("MLFLOW_RUN_NAME", None)
+        self.assertIsNone(MLflow.get_run_name())
+
+    @mock.patch.dict(os.environ, {"MLFLOW_RUN_NAME": "  run_1645 "})
+    def test_get_run_name_run_1645(self) -> None:
+        self.assertEqual("run_1645", MLflow.get_run_name())

--- a/training/xtime/contrib/mlflow_ext.py
+++ b/training/xtime/contrib/mlflow_ext.py
@@ -247,3 +247,14 @@ class MLflow(object):
         if not matches or matches[0] != run_id:
             logger.warning("Probably invalid MLflow URL (%s). Run ID was resolved to '%s'.", url, run_id)
         return run_id
+
+    @staticmethod
+    def get_run_name() -> t.Optional[str]:
+        """Return MLflow run name from environment variable.
+        Returns:
+            Run name (string) or None if not set.
+        """
+        run_name: t.Optional[str] = os.environ.get("MLFLOW_RUN_NAME", None)
+        if isinstance(run_name, str):
+            run_name = run_name.strip()
+        return run_name

--- a/training/xtime/stages/search_hp.py
+++ b/training/xtime/stages/search_hp.py
@@ -67,7 +67,7 @@ def search_hp(
 
     ray_tune_extensions.add_representers()
     MLflow.create_experiment()
-    with mlflow.start_run(description=" ".join(sys.argv)) as active_run:
+    with mlflow.start_run(description=" ".join(sys.argv), run_name=MLflow.get_run_name()) as active_run:
         # This MLflow run tracks Ray Tune hyperparameter search. Individual trials won't have their own MLflow runs.
         MLflow.init_run(active_run)
         IO.save_yaml(

--- a/training/xtime/stages/train.py
+++ b/training/xtime/stages/train.py
@@ -38,7 +38,7 @@ def train(dataset: str, model: str, hparams: t.Optional[HParamsSource]) -> None:
     """
     ray_tune_extensions.add_representers()
     MLflow.create_experiment()
-    with mlflow.start_run(description=" ".join(sys.argv)) as active_run:
+    with mlflow.start_run(description=" ".join(sys.argv), run_name=MLflow.get_run_name()) as active_run:
         # This MLflow run tracks model training.
         MLflow.init_run(active_run)
         IO.save_yaml(


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Users can configure MLflow run names using `MLFLOW_RUN_NAME` environment variable. This is supported in `search_hp` and `train` stages.

# What changes are proposed in this pull request?

Select one of these options, and delete the others.

- [x] New feature.

# Checklist:

Select all that apply, and delete the others. If these changes are for `xtime.training`, please make sure to
provide unit tests and/or nox tests for bug fixes and new features.

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] I have commented my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
