### PR TITLE
Removing redundant logging call.

### DIFF
--- a/training/xtime/io.py
+++ b/training/xtime/io.py
@@ -165,7 +165,6 @@ class IO(object):
                 data,
                 _object_to_debug_str(data),
             )
-            logger.debug("", _object_to_debug_str(data))
             if raise_on_error:
                 raise
 


### PR DESCRIPTION
# Description

Two logging calls - warning and debug, with debug call printing the same information.

# What changes are proposed in this pull request?

- [x] Other (code cleaning)

# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] If applicable, new and existing unit tests pass locally with my changes.

