### PR TITLE
Removing type annotations from `typing` package.

### DIFF
--- a/training/noxfile.py
+++ b/training/noxfile.py
@@ -16,8 +16,8 @@
 
 import inspect
 import os
-import typing as t
 from pathlib import Path
+from typing import Callable
 
 import nox
 import tomlkit
@@ -68,7 +68,7 @@ def unit_tests(session: nox.Session, deps: str) -> None:
             must be available externally.
     """
     # Install this project and pytest (with `pip install`).
-    install_args: t.List[str] = [".[all]", "pytest", "pytest-xdist"]
+    install_args: list[str] = [".[all]", "pytest", "pytest-xdist"]
 
     # If pinned deps to be used, export constraints from `poetry.lock` file using `poetry`.
     if deps == "pinned":
@@ -204,7 +204,6 @@ def _validate_search_hp_run() -> None:
     folder.
     """
     import os
-    import typing as t
 
     import mlflow
     from mlflow.entities import Run
@@ -218,7 +217,7 @@ def _validate_search_hp_run() -> None:
     num_search_trials: int = int(os.environ["XTIME_NUM_SEARCH_TRIALS"])
 
     # There must be one experiment (Default + this one).
-    experiment_ids: t.List[str] = MLflow.get_experiment_ids()
+    experiment_ids: list[str] = MLflow.get_experiment_ids()
     assert (
         len(experiment_ids) == 2
     ), f"Expected two experiments (Default and {experiment_name}), but got {len(experiment_ids)}."
@@ -227,7 +226,7 @@ def _validate_search_hp_run() -> None:
     ), "Unexpected experiment name (s)."
 
     # There must be one run
-    runs: t.List[Run] = MLflow.get_runs()
+    runs: list[Run] = MLflow.get_runs()
     assert len(runs) == 1, f"Expected one run, but got {len(runs)}."
 
     # Verify run outputs
@@ -265,12 +264,12 @@ def _validate_search_hp_run() -> None:
     )
 
     # Validate ray tune trials using ray tune API
-    trial_stats: t.List[t.Dict] = Analysis.get_trial_stats(run.info.run_id, skip_model_stats=True)
+    trial_stats: list[dict] = Analysis.get_trial_stats(run.info.run_id, skip_model_stats=True)
     assert (
         len(trial_stats) == num_search_trials
     ), f"Number of trials do not match ({len(trial_stats)} != {num_search_trials})."
 
-    summary_from_api: t.Dict = Analysis.get_summary(run.info.run_id)
+    summary_from_api: dict = Analysis.get_summary(run.info.run_id)
     assert all(k in summary_from_file for k in summary_from_api.keys()), "Summary from API does not contain all keys."
 
     best_trial = Analysis.get_best_trial(run.info.run_id)
@@ -308,7 +307,7 @@ def _validate_train_run() -> None:
     print(f"[validate_train_run] 00/{n} start validation experiment={experiment_name}, model={model_name}.")
 
     # There must be one experiment.
-    experiment_ids: t.List[str] = MLflow.get_experiment_ids()
+    experiment_ids: list[str] = MLflow.get_experiment_ids()
     if len(experiment_ids) != 2:
         raise ValueError(f"Expected two experiments (Default and {experiment_name}), but got {len(experiment_ids)}.")
     for experiment_id in experiment_ids:
@@ -318,7 +317,7 @@ def _validate_train_run() -> None:
     print(f"[validate_train_run] 01/{n} experiments validated experiment_ids={experiment_ids}.")
 
     # There must be one run
-    runs: t.List[Run] = MLflow.get_runs()
+    runs: list[Run] = MLflow.get_runs()
     if len(runs) != 1:
         raise ValueError(f"Expected one run, but got {len(runs)}.")
     print(f"[validate_train_run] 02/{n} runs validated run_ids=[{runs[0].info.run_id}].")
@@ -419,7 +418,7 @@ def _validate_xtime_train_run(train_dir: Path, model_name: str) -> None:
     assert model is not None, "Failed to load the model."
 
 
-def _create_validate_file(location: Path, main_fn: t.Callable, deps: t.List[t.Callable]) -> Path:
+def _create_validate_file(location: Path, main_fn: Callable, deps: list[Callable]) -> Path:
     """Create a `validate.py` file to run in a nox session to validate outputs if XTIME stages (train / search_hp).
 
     Args:

--- a/training/tests/contrib/test_tune_ext.py
+++ b/training/tests/contrib/test_tune_ext.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-import typing as t
+from typing import Any, Type
 from unittest import TestCase
 
 import ray.tune.search.sample as sample
@@ -49,7 +49,7 @@ class TestYamlRepresenters(TestCase):
         """Test serialization/deserialization for categorical domain (`Categorical`)."""
         cats = ["Garfield", "Tom Cat", "Puss in Boots"]
 
-        def _check(_rv: sample.Categorical, _sampler_t: t.Optional[t.Type]) -> None:
+        def _check(_rv: sample.Categorical, _sampler_t: Type | None) -> None:
             self.assertIsInstance(_rv, sample.Categorical)
             self.assertListEqual(cats, _rv.categories)
             self._check_sampler(type(_rv), _rv.sampler, sampler_type=_sampler_t)
@@ -69,22 +69,22 @@ class TestYamlRepresenters(TestCase):
 
         return deserialized_rv
 
-    def _check_object_type(self, obj: t.Any, expected_type: t.Optional[t.Type]) -> None:
+    def _check_object_type(self, obj: Any, expected_type: Type | None) -> None:
         if expected_type is None:
             self.assertIsNone(obj)
         else:
             self.assertIsInstance(obj, expected_type)
 
-    def _test_uniform_samplers(self, domain_t: t.Union[t.Type[sample.Integer], t.Type[sample.Float]]) -> None:
+    def _test_uniform_samplers(self, domain_t: Type[sample.Integer] | Type[sample.Float]) -> None:
         lower, upper, base, q = (10, 100, 6, 2)
 
         self.assertIn(domain_t, {sample.Integer, sample.Float}, "Invalid domain type.")
 
         def _check(
-            _rv: t.Union[sample.Integer, sample.Float],
-            _sampler_t: t.Optional[t.Type],
-            _q: t.Optional[int] = None,
-            _base: t.Optional[int] = None,
+            _rv: sample.Integer | sample.Float,
+            _sampler_t: Type | None,
+            _q: int | None = None,
+            _base: int | None = None,
         ) -> None:
             self.assertIsInstance(_rv, domain_t)
             self.assertEqual(lower, _rv.lower)
@@ -122,7 +122,7 @@ class TestYamlRepresenters(TestCase):
         mean, sd = 1.1, 0.45
         q = 0.1
 
-        def _check(_rv: sample.Float, _sampler_t: t.Optional[t.Type], _q: t.Optional[float] = None) -> None:
+        def _check(_rv: sample.Float, _sampler_t: Type | None, _q: float | None = None) -> None:
             self.assertEqual(float("-inf"), _rv.lower)
             self.assertEqual(float("+inf"), _rv.upper)
             self._check_sampler(type(_rv), _rv.sampler, sampler_type=_sampler_t, q=_q, mean=mean, sd=sd)
@@ -135,13 +135,13 @@ class TestYamlRepresenters(TestCase):
 
     def _check_sampler(
         self,
-        rv_type: t.Type,
-        sampler: t.Optional[sample.Sampler],
-        sampler_type: t.Optional[t.Type] = None,
-        base: t.Optional[int] = None,
-        q: t.Optional[t.Union[int, float]] = None,
-        mean: t.Optional[float] = None,
-        sd: t.Optional[float] = None,
+        rv_type: Type,
+        sampler: sample.Sampler | None,
+        sampler_type: Type | None = None,
+        base: int | None = None,
+        q: int | float | None = None,
+        mean: float | None = None,
+        sd: float | None = None,
     ) -> None:
         if q is not None:
             #

--- a/training/tests/datasets/test_dataset.py
+++ b/training/tests/datasets/test_dataset.py
@@ -15,7 +15,6 @@
 ###
 import pickle
 import sys
-import typing as t
 from pathlib import Path
 from unittest import TestCase, mock
 
@@ -30,7 +29,7 @@ from xtime.errors import DatasetError
 
 
 class TestDataset(TestCase):
-    def _check_serialized_dataset_structure(self, directory: Path, splits: t.List[str]) -> None:
+    def _check_serialized_dataset_structure(self, directory: Path, splits: list[str]) -> None:
         """Check serialized dataset structure.
 
         Args:
@@ -78,7 +77,7 @@ class TestDataset(TestCase):
 
     def test_registered_dataset_factory(self) -> None:
         # Get all registered datasets
-        dataset_names: t.List[str] = []
+        dataset_names: list[str] = []
         for dataset_name in RegisteredDatasetFactory.registry.keys():
             for dataset_version in RegisteredDatasetFactory.registry.get(dataset_name)().builders.keys():
                 dataset_names.append(f"{dataset_name}:{dataset_version}")
@@ -86,7 +85,7 @@ class TestDataset(TestCase):
         self.assertTrue(len(dataset_names) > 0, "No registered datasets found.")
         #
         for dataset_name in dataset_names:
-            factories: t.List[DatasetFactory] = DatasetFactory.resolve_factories(dataset_name)
+            factories: list[DatasetFactory] = DatasetFactory.resolve_factories(dataset_name)
             self.assertEqual(1, len(factories), f"Expected one factory for '{dataset_name}' dataset.")
             self.assertIsInstance(
                 factories[0],

--- a/training/tests/datasets/test_preprocessing.py
+++ b/training/tests/datasets/test_preprocessing.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-import typing as t
 from functools import partial
 from unittest import TestCase
 
@@ -78,13 +77,13 @@ class TestTimeSeriesEncoderV1(TestCase):
     NUM_FEATURES = 19
 
     def test_features(self) -> None:
-        features: t.List[str] = TimeSeriesEncoderV1().features()
+        features: list[str] = TimeSeriesEncoderV1().features()
         self.assertIsInstance(features, list)
         self.assertEqual(TestTimeSeriesEncoderV1.NUM_FEATURES, len(features))
         for feature in features:
             self.assertIsInstance(feature, str)
 
-    def _check_features(self, features: t.Dict[str, t.Union[float, int]], num_ts: int = 1) -> None:
+    def _check_features(self, features: dict[str, float | int], num_ts: int = 1) -> None:
         self.assertIsInstance(features, dict)
         self.assertEqual(TestTimeSeriesEncoderV1.NUM_FEATURES * num_ts, len(features))
         for name, value in features.items():
@@ -103,17 +102,17 @@ class TestTimeSeriesEncoderV1(TestCase):
     def test_encode_many(self) -> None:
         encoder = TimeSeriesEncoderV1()
 
-        feature_list: t.List[t.Dict] = encoder.encode_many(np.random.randn(10, 100))
+        feature_list: list[dict] = encoder.encode_many(np.random.randn(10, 100))
         self.assertIsInstance(feature_list, list)
         for features in feature_list:
             self._check_features(features)
 
-        feature_list: t.List[t.Dict] = encoder.encode_many(np.random.randn(10, 100, 1))
+        feature_list: list[dict] = encoder.encode_many(np.random.randn(10, 100, 1))
         self.assertIsInstance(feature_list, list)
         for features in feature_list:
             self._check_features(features)
 
-        feature_list: t.List[t.Dict] = encoder.encode_many(np.random.randn(10, 100, 2), prefixes=["x_", "y_"])
+        feature_list: list[dict] = encoder.encode_many(np.random.randn(10, 100, 2), prefixes=["x_", "y_"])
         self.assertIsInstance(feature_list, list)
         for features in feature_list:
             self._check_features(features, num_ts=2)

--- a/training/tests/estimators/test_catboost.py
+++ b/training/tests/estimators/test_catboost.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-import typing as t
 from unittest import TestCase
 
 import pytest
@@ -32,7 +31,7 @@ class TestCatboostEstimator(TestCase):
         ds: Dataset = Dataset.create("churn_modelling:numerical")
         self.assertIsInstance(ds, Dataset)
 
-        metrics: t.Dict = unit_test_train_model(self, "catboost", CatboostEstimator, ds)
+        metrics: dict = unit_test_train_model(self, "catboost", CatboostEstimator, ds)
         unit_test_check_metrics(self, ds.metadata.task, metrics)
 
     @with_temp_work_dir
@@ -40,5 +39,5 @@ class TestCatboostEstimator(TestCase):
         ds: Dataset = Dataset.create("year_prediction_msd:default")
         self.assertIsInstance(ds, Dataset)
 
-        metrics: t.Dict = unit_test_train_model(self, "catboost", CatboostEstimator, ds)
+        metrics: dict = unit_test_train_model(self, "catboost", CatboostEstimator, ds)
         unit_test_check_metrics(self, ds.metadata.task, metrics)

--- a/training/tests/estimators/test_lightgbm.py
+++ b/training/tests/estimators/test_lightgbm.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-import typing as t
 from unittest import TestCase
 
 import pytest
@@ -32,7 +31,7 @@ class TestLightGBMEstimator(TestCase):
         ds: Dataset = Dataset.create("churn_modelling:numerical")
         self.assertIsInstance(ds, Dataset)
 
-        metrics: t.Dict = unit_test_train_model(self, "lightgbm", LightGBMClassifierEstimator, ds)
+        metrics: dict = unit_test_train_model(self, "lightgbm", LightGBMClassifierEstimator, ds)
         unit_test_check_metrics(self, ds.metadata.task, metrics)
 
     @with_temp_work_dir
@@ -40,5 +39,5 @@ class TestLightGBMEstimator(TestCase):
         ds: Dataset = Dataset.create("year_prediction_msd:default")
         self.assertIsInstance(ds, Dataset)
 
-        metrics: t.Dict = unit_test_train_model(self, "lightgbm", LightGBMClassifierEstimator, ds)
+        metrics: dict = unit_test_train_model(self, "lightgbm", LightGBMClassifierEstimator, ds)
         unit_test_check_metrics(self, ds.metadata.task, metrics)

--- a/training/tests/estimators/test_model_loader.py
+++ b/training/tests/estimators/test_model_loader.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 ###
 import os
-import typing as t
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
@@ -63,7 +62,7 @@ class TestModelLoader(TestCase):
         x, y = x.astype("float32"), y.astype("int32")
         x_train, x_test, y_train, y_test = train_test_split(x, y, train_size=0.8, random_state=42)
 
-        feature_names: t.List[str] = [f"feature_{i}" for i in range(num_features)]
+        feature_names: list[str] = [f"feature_{i}" for i in range(num_features)]
         type_ = TaskType.BINARY_CLASSIFICATION if num_classes == 2 else TaskType.MULTI_CLASS_CLASSIFICATION
         return Dataset(
             metadata=DatasetMetadata(
@@ -96,7 +95,7 @@ class TestModelLoader(TestCase):
         x, y = x.astype("float32"), y.astype("int32")
         x_train, x_test, y_train, y_test = train_test_split(x, y, train_size=0.8, random_state=42)
 
-        feature_names: t.List[str] = [f"feature_{i}" for i in range(num_features)]
+        feature_names: list[str] = [f"feature_{i}" for i in range(num_features)]
         return Dataset(
             metadata=DatasetMetadata(
                 name="random-regression-dataset",
@@ -115,7 +114,7 @@ class TestModelLoader(TestCase):
         self.regression_dataset = self.make_regression_dataset()
 
     def _test_manual_loading(
-        self, estimator_cls: t.Type[Estimator], model_cls: t.Type, dataset: Dataset, params: t.Optional[t.Dict] = None
+        self, estimator_cls: type[Estimator], model_cls: type, dataset: Dataset, params: dict | None = None
     ) -> None:
         if params is None:
             params = {"n_estimators": 5}
@@ -130,7 +129,7 @@ class TestModelLoader(TestCase):
             self.assertIsInstance(model, model_cls)
 
     def _test_automated_loading(
-        self, estimator_cls: t.Type[Estimator], model_cls: t.Type, dataset: Dataset, params: t.Optional[t.Dict] = None
+        self, estimator_cls: type[Estimator], model_cls: type, dataset: Dataset, params: dict | None = None
     ) -> None:
         if params is None:
             params = {"n_estimators": 5}

--- a/training/tests/estimators/test_xgboost.py
+++ b/training/tests/estimators/test_xgboost.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-import typing as t
 from unittest import TestCase
 
 import pytest
@@ -32,7 +31,7 @@ class TestXGBoostEstimator(TestCase):
         ds: Dataset = Dataset.create("churn_modelling:numerical")
         self.assertIsInstance(ds, Dataset)
 
-        metrics: t.Dict = unit_test_train_model(self, "xgboost", XGBoostEstimator, ds)
+        metrics: dict = unit_test_train_model(self, "xgboost", XGBoostEstimator, ds)
         unit_test_check_metrics(self, ds.metadata.task, metrics)
 
     @with_temp_work_dir
@@ -40,5 +39,5 @@ class TestXGBoostEstimator(TestCase):
         ds: Dataset = Dataset.create("year_prediction_msd:default")
         self.assertIsInstance(ds, Dataset)
 
-        metrics: t.Dict = unit_test_train_model(self, "xgboost", XGBoostEstimator, ds)
+        metrics: dict = unit_test_train_model(self, "xgboost", XGBoostEstimator, ds)
         unit_test_check_metrics(self, ds.metadata.task, metrics)

--- a/training/tests/hparams/test_hparams.py
+++ b/training/tests/hparams/test_hparams.py
@@ -15,7 +15,6 @@
 ###
 
 import tempfile
-import typing as t
 from pathlib import Path
 from unittest import TestCase
 
@@ -40,7 +39,7 @@ class TestUtils(TestCase):
         )
         return hparams_file
 
-    def _check_randint_value_spec(self, params: t.Dict) -> None:
+    def _check_randint_value_spec(self, params: dict) -> None:
         self.assertIsInstance(params, dict)
         self.assertEqual(1, len(params))
         self.assertIn("max_depth", params)
@@ -64,7 +63,7 @@ class TestUtils(TestCase):
         self.assertDictEqual({}, hp.get_hparams({}))
         self.assertDictEqual({"a": 1}, hp.get_hparams({"a": 1}))
         self.assertDictEqual({"a": 1, "b": 2}, hp.get_hparams({"a": 1, "b": 2}))
-        params: t.Dict = hp.get_hparams({"max_depth": hp.ValueSpec(int, 6, tune.randint(1, 11))})
+        params: dict = hp.get_hparams({"max_depth": hp.ValueSpec(int, 6, tune.randint(1, 11))})
         self._check_randint_value_spec(params)
 
     def test_from_string(self) -> None:
@@ -75,7 +74,7 @@ class TestUtils(TestCase):
             hp.get_hparams("max_leaves=256;max_depth=6;learning_rate=0.01;verbose=True;msg='hello'"),
         )
 
-        params: t.Dict = hp.get_hparams("max_depth=ValueSpec(int, 6, tune.randint(1, 11))")
+        params: dict = hp.get_hparams("max_depth=ValueSpec(int, 6, tune.randint(1, 11))")
         self._check_randint_value_spec(params)
 
     def test_from_params_protocol(self) -> None:
@@ -97,7 +96,7 @@ class TestUtils(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             hparams_file: Path = self._save_example_hparams_config_to_file(tmp_dir, "hparams", "yaml")
 
-            hparams: t.Dict = hp.get_hparams(f"file:{hparams_file.as_posix()}")
+            hparams: dict = hp.get_hparams(f"file:{hparams_file.as_posix()}")
             self.assertIsInstance(hparams, dict)
             self.assertIn("max_depth", hparams)
 
@@ -110,7 +109,7 @@ class TestUtils(TestCase):
         tmp_dir: str
         with tempfile.TemporaryDirectory() as tmp_dir:
             hparams_file: Path = self._save_example_hparams_config_to_file(tmp_dir, "hparams", "yaml")
-            hparams: t.Dict = hp.get_hparams(
+            hparams: dict = hp.get_hparams(
                 [None, "", f"file:{hparams_file.as_posix()}", {}, "msg='hello_2'", {"a": 100}]
             )
             self.assertIsInstance(hparams, dict)

--- a/training/tests/hparams/test_recommender.py
+++ b/training/tests/hparams/test_recommender.py
@@ -13,18 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-import typing as t
+from typing import TypeVar
 from unittest import TestCase
 
 from xtime.hparams import get_hparams
 from xtime.ml import Task
 
-TaskLike = t.TypeVar("TaskLike", bound=Task)
+TaskLike = TypeVar("TaskLike", bound=Task)
 
 
 class TestRecommender(TestCase):
     def test_default_lightgbm(self):
-        params: t.Dict = get_hparams("auto:default:model=lightgbm;task=multi_class_classification")
+        params: dict = get_hparams("auto:default:model=lightgbm;task=multi_class_classification")
         self.assertIsInstance(params, dict)
         self.assertDictEqual(
             params,
@@ -40,22 +40,22 @@ class TestRecommender(TestCase):
         )
 
     def test_default_dummy_classifier(self):
-        params: t.Dict = get_hparams("auto:default:model=dummy;task=multi_class_classification")
+        params: dict = get_hparams("auto:default:model=dummy;task=multi_class_classification")
         self.assertIsInstance(params, dict)
         self.assertDictEqual(params, {"strategy": "prior", "random_state": 1})
 
     def test_default_dummy_regressor(self):
-        params: t.Dict = get_hparams("auto:default:model=dummy;task=regression")
+        params: dict = get_hparams("auto:default:model=dummy;task=regression")
         self.assertIsInstance(params, dict)
         self.assertDictEqual(params, {"strategy": "mean"})
 
     def test_default_rf(self):
-        params: t.Dict = get_hparams("auto:default:model=rf;task=multi_class_classification")
+        params: dict = get_hparams("auto:default:model=rf;task=multi_class_classification")
         self.assertIsInstance(params, dict)
         self.assertDictEqual(params, {"n_estimators": 100, "max_depth": 6, "random_state": 1})
 
     def test_default_catboost(self):
-        params: t.Dict = get_hparams("auto:default:model=catboost;task=multi_class_classification")
+        params: dict = get_hparams("auto:default:model=catboost;task=multi_class_classification")
         self.assertIsInstance(params, dict)
         self.assertDictEqual(
             params,
@@ -71,7 +71,7 @@ class TestRecommender(TestCase):
         )
 
     def test_default_xgboost(self):
-        params: t.Dict = get_hparams("auto:default:model=xgboost;task=multi_class_classification")
+        params: dict = get_hparams("auto:default:model=xgboost;task=multi_class_classification")
         self.assertIsInstance(params, dict)
         self.assertDictEqual(
             params,

--- a/training/tests/test_cli.py
+++ b/training/tests/test_cli.py
@@ -15,7 +15,6 @@
 ###
 
 import logging
-import typing as t
 from unittest import TestCase
 
 import pytest
@@ -115,8 +114,8 @@ class TestMain(TestCase):
         result: Result = CliRunner().invoke(model_list, [])
         self.assertEqual(result.exit_code, 0)
 
-        output_lines: t.List[str] = result.output.splitlines()
+        output_lines: list[str] = result.output.splitlines()
         self.assertEqual(output_lines[0].strip(), "Available models:")
 
-        available_models: t.List[str] = sorted((line[2:] for line in output_lines[1:] if line.startswith("- ")))
+        available_models: list[str] = sorted((line[2:] for line in output_lines[1:] if line.startswith("- ")))
         self.assertListEqual(available_models, get_expected_available_estimators())

--- a/training/tests/test_registry.py
+++ b/training/tests/test_registry.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 ###
 
-import typing as t
 from unittest import TestCase
 
 from xtime.datasets import DatasetBuilder, RegisteredDatasetFactory
@@ -23,7 +22,7 @@ from xtime.estimators.estimator import get_expected_available_estimators
 
 
 class TestRegistry(TestCase):
-    def check_registry(self, registry, keys: t.List[str], base_cls):
+    def check_registry(self, registry, keys: list[str], base_cls):
         for key in keys:
             self.assertTrue(issubclass(registry.get(key), base_cls))
 

--- a/training/xtime/contrib/sklearn_ext.py
+++ b/training/xtime/contrib/sklearn_ext.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-import typing as t
 from pathlib import Path
 
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
@@ -25,7 +24,7 @@ from xtime.ml import TaskType
 __all__ = ["get_model_stats"]
 
 
-def get_model_stats(model_path: Path, task_type: TaskType) -> t.Dict:
+def get_model_stats(model_path: Path, task_type: TaskType) -> dict:
     """Compute some basic statistics of a mode.
 
     Args:
@@ -35,7 +34,7 @@ def get_model_stats(model_path: Path, task_type: TaskType) -> t.Dict:
     Returns:
         Dictionary with some descriptive statistics of this model.
     """
-    model: t.Union[RandomForestClassifier, RandomForestRegressor] = Model.load_model(
+    model: RandomForestClassifier | RandomForestRegressor = Model.load_model(
         model_path, LegacySavedModelInfo("rf", task_type.value)
     )
     if not isinstance(model, (RandomForestClassifier, RandomForestRegressor)):

--- a/training/xtime/contrib/unittest_ext.py
+++ b/training/xtime/contrib/unittest_ext.py
@@ -16,14 +16,13 @@
 import functools
 import os
 import tempfile
-import typing as t
 from enum import Enum
 from unittest import TestCase
 
 __all__ = ["check_enum", "CurrentWorkingDirectory", "with_temp_work_dir"]
 
 
-def check_enum(test_case: TestCase, enum_cls: t.Type[Enum], enum_var: Enum, name: str, value: str) -> None:
+def check_enum(test_case: TestCase, enum_cls: type[Enum], enum_var: Enum, name: str, value: str) -> None:
     test_case.assertEqual(enum_var.name, name)
     test_case.assertEqual(enum_var.value, value)
     test_case.assertIs(enum_cls(enum_var), enum_var)
@@ -39,7 +38,7 @@ class CurrentWorkingDirectory:
 
     def __init__(self, directory: str):
         self._new_directory = directory
-        self._old_directory: t.Optional[str] = None
+        self._old_directory: str | None = None
 
     def __enter__(self):
         self._old_directory = os.getcwd()
@@ -49,7 +48,7 @@ class CurrentWorkingDirectory:
         os.chdir(self._old_directory)
 
 
-def with_temp_work_dir(fn: t.Callable) -> t.Callable:
+def with_temp_work_dir(fn: callable) -> callable:
     """Decorator to run a function or method (for test cases) in a temporary working directory.
     https://stackoverflow.com/a/170174/575749
 

--- a/training/xtime/contrib/xgboost_ext.py
+++ b/training/xtime/contrib/xgboost_ext.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 ###
 import json
-import typing as t
 from pathlib import Path
 
 import pandas as pd
@@ -37,7 +36,7 @@ class TreeTraversal:
         self.num_leaves = 0
         """Number of leaves in a tree."""
 
-    def traverse(self, node: t.Dict) -> "TreeTraversal":
+    def traverse(self, node: dict) -> "TreeTraversal":
         """Traverse the tree starting with `node` node."""
         self.depth = 0
         self.num_leaves = 0
@@ -49,14 +48,14 @@ class TreeTraversal:
     def __repr__(self) -> str:
         return f"TreeTraversal(depth={self.depth}, num_leaves={self.num_leaves}, num_nodes={self.num_nodes})"
 
-    def as_dict(self, prefix: str = "") -> t.Dict:
+    def as_dict(self, prefix: str = "") -> dict:
         return {
             f"{prefix}depth": self.depth,
             f"{prefix}num_leaves": self.num_leaves,
             f"{prefix}num_nodes": self.num_nodes,
         }
 
-    def _traverse(self, node: t.Dict) -> None:
+    def _traverse(self, node: dict) -> None:
         """Recursively traverse the tree."""
         if not isinstance(node, dict) or "nodeid" not in node:
             return
@@ -70,9 +69,7 @@ class TreeTraversal:
                 self._traverse(child)
 
 
-def get_model_stats(
-    model_dir: Path, task_type: TaskType, num_trees: int = 0, cache: t.Optional[t.Dict] = None
-) -> t.Dict:
+def get_model_stats(model_dir: Path, task_type: TaskType, num_trees: int = 0, cache: dict | None = None) -> dict:
     """Compute some basic statistics of an XGBoost model.
 
     Args:
@@ -88,7 +85,7 @@ def get_model_stats(
         to actual number of trees, then number of trees will equal to this number.
     """
 
-    def _get_stats(_trees: pd.DataFrame) -> t.Dict:
+    def _get_stats(_trees: pd.DataFrame) -> dict:
         _num_trees = _trees.shape[0] if num_trees <= 0 else min(num_trees, _trees.shape[0])
         return {
             "max_depth": _trees["depth"][0:_num_trees].max(),

--- a/training/xtime/datasets/_churn_modelling.py
+++ b/training/xtime/datasets/_churn_modelling.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 ###
 import functools
-import typing as t
 from pathlib import Path
 
 import pandas as pd
@@ -41,7 +40,7 @@ from ..errors import DatasetError
 class ChurnModellingBuilder(DatasetBuilder):
     NAME = "churn_modelling"
 
-    def __init__(self, path: t.Optional[t.Union[str, Path]] = None, **kwargs) -> None:
+    def __init__(self, path: str | Path | None = None, **kwargs) -> None:
         super().__init__()
         self.builders.update(
             default=self._build_default_dataset,

--- a/training/xtime/datasets/_fraud_detection.py
+++ b/training/xtime/datasets/_fraud_detection.py
@@ -16,7 +16,6 @@
 
 import logging
 import os
-import typing as t
 from pathlib import Path
 
 import pandas as pd
@@ -59,7 +58,7 @@ class FDBuilder(DatasetBuilder):
         super().__init__()
         self.builders.update(default=self._build_default_dataset)
         self.encoder = TimeSeriesEncoderV1()
-        self._dataset_dir: t.Optional[Path] = None
+        self._dataset_dir: Path | None = None
 
     def _check_pre_requisites(self) -> None:
         # Check raw dataset exists.

--- a/training/xtime/datasets/_harth.py
+++ b/training/xtime/datasets/_harth.py
@@ -17,7 +17,6 @@
 import logging
 import os
 import re
-import typing as t
 from itertools import product
 from pathlib import Path
 
@@ -88,7 +87,7 @@ class HARTHBuilder(DatasetBuilder):
         super().__init__()
         self.builders.update(default=self._build_default_dataset)
         self.encoder = TimeSeriesEncoderV1()
-        self._dataset_dir: t.Optional[Path] = None
+        self._dataset_dir: Path | None = None
 
     def _check_pre_requisites(self) -> None:
         # Check raw dataset exists.
@@ -175,7 +174,7 @@ class HARTHBuilder(DatasetBuilder):
         )
         return dataset
 
-    def extract_subject_id(self, file_name: str) -> t.Optional[str]:
+    def extract_subject_id(self, file_name: str) -> str | None:
         """Extract subject ID from a file name.
 
         Regular expression pattern to match subject ID

--- a/training/xtime/datasets/_madeline.py
+++ b/training/xtime/datasets/_madeline.py
@@ -16,7 +16,6 @@
 
 import logging
 import os
-import typing as t
 from pathlib import Path
 
 import pandas as pd
@@ -56,7 +55,7 @@ class MADELINEBuilder(DatasetBuilder):
         super().__init__()
         self.builders.update(default=self._build_default_dataset)
         self.encoder = TimeSeriesEncoderV1()
-        self._dataset_dir: t.Optional[Path] = None
+        self._dataset_dir: Path | None = None
 
     def _check_pre_requisites(self) -> None:
         # Check raw dataset exists.

--- a/training/xtime/datasets/_ozone_level_detection_one_hour.py
+++ b/training/xtime/datasets/_ozone_level_detection_one_hour.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import typing as t
 from pathlib import Path
 
 import numpy as np
@@ -45,7 +44,7 @@ class OLD1HRBuilder(DatasetBuilder):
         super().__init__()
         self.builders.update(default=self._build_default_dataset)
         self.encoder = TimeSeriesEncoderV1()
-        self._dataset_dir: t.Optional[Path] = None
+        self._dataset_dir: Path | None = None
 
     def _check_pre_requisites(self) -> None:
         # Check raw dataset exists.

--- a/training/xtime/datasets/_wisdm.py
+++ b/training/xtime/datasets/_wisdm.py
@@ -16,7 +16,6 @@
 
 import logging
 import os
-import typing as t
 from itertools import product
 from pathlib import Path
 
@@ -60,7 +59,7 @@ class WISDMBuilder(DatasetBuilder):
         super().__init__()
         self.builders.update(default=self._build_default_dataset)
         self.encoder = TimeSeriesEncoderV1()
-        self._dataset_dir: t.Optional[Path] = None
+        self._dataset_dir: Path | None = None
 
     def _check_pre_requisites(self) -> None:
         # Check raw dataset exists.

--- a/training/xtime/errors.py
+++ b/training/xtime/errors.py
@@ -15,7 +15,7 @@
 ###
 import functools
 import logging
-import typing as t
+from typing import Any
 
 __all__ = [
     "maybe_suggest_debug_level",
@@ -28,7 +28,7 @@ __all__ = [
 ]
 
 
-def maybe_suggest_debug_level(logger: t.Optional[logging.Logger] = None, prefix: str = " ", suffix: str = ".") -> str:
+def maybe_suggest_debug_level(logger: logging.Logger | None = None, prefix: str = " ", suffix: str = ".") -> str:
     if logger is None or not logger.isEnabledFor(logging.DEBUG):
         return (
             f"{prefix}Detailed information is logged when logging level is "
@@ -37,11 +37,11 @@ def maybe_suggest_debug_level(logger: t.Optional[logging.Logger] = None, prefix:
     return ""
 
 
-def exception_if_debug(error: Exception, logger: logging.Logger) -> t.Optional[Exception]:
+def exception_if_debug(error: Exception, logger: logging.Logger) -> Exception | None:
     return error if logger.isEnabledFor(logging.DEBUG) else None
 
 
-def ignore_exceptions(default_value: t.Any = None):
+def ignore_exceptions(default_value: Any = None):
     """Function decorator that can be used to suppress all exceptions raised by the decorated function.
 
     Args:
@@ -101,7 +101,7 @@ class EstimatorError(XTimeError):
         return error
 
     @classmethod
-    def library_not_installed(cls, estimator: str, library: str, dep_groups: t.List[str]) -> "EstimatorError":
+    def library_not_installed(cls, estimator: str, library: str, dep_groups: list[str]) -> "EstimatorError":
         return EstimatorError.missing_prerequisites(
             f"{estimator} estimator is not available because `{library}` library is not installed. "
             f"This library is optional in XTIME and should be installed by specifying one of the following optional "

--- a/training/xtime/estimators/_catboost.py
+++ b/training/xtime/estimators/_catboost.py
@@ -15,7 +15,6 @@
 ###
 
 import copy
-import typing as t
 from pathlib import Path
 
 from xtime.errors import DatasetError
@@ -46,7 +45,7 @@ class CatboostEstimator(Estimator):
         TaskType.REGRESSION: "RMSE",
     }
 
-    def __init__(self, params: t.Dict, dataset_metadata: DatasetMetadata) -> None:
+    def __init__(self, params: dict, dataset_metadata: DatasetMetadata) -> None:
         super().__init__()
         params = copy.deepcopy(params)
         params.update(

--- a/training/xtime/estimators/_lightgbm.py
+++ b/training/xtime/estimators/_lightgbm.py
@@ -15,8 +15,8 @@
 ###
 
 import copy
-import typing as t
 from pathlib import Path
+from typing import cast
 
 try:
     from lightgbm.sklearn import LGBMClassifier, LGBMModel, LGBMRegressor
@@ -38,13 +38,13 @@ __all__ = ["LightGBMClassifierEstimator"]
 class LightGBMClassifierEstimator(Estimator):
     NAME = "lightgbm"
 
-    OBJECTIVES: t.Dict[TaskType, str] = {
+    OBJECTIVES: dict[TaskType, str] = {
         TaskType.BINARY_CLASSIFICATION: "binary",
         TaskType.MULTI_CLASS_CLASSIFICATION: "multiclass",
         TaskType.REGRESSION: "regression",
     }
 
-    def __init__(self, params: t.Dict, dataset_metadata: DatasetMetadata) -> None:
+    def __init__(self, params: dict, dataset_metadata: DatasetMetadata) -> None:
         """
         https://lightgbm.readthedocs.io/en/latest/Parameters.html
         """
@@ -52,7 +52,7 @@ class LightGBMClassifierEstimator(Estimator):
         params = copy.deepcopy(params)
         params["objective"] = LightGBMClassifierEstimator.OBJECTIVES[dataset_metadata.task.type]
         if dataset_metadata.task.type == TaskType.MULTI_CLASS_CLASSIFICATION:
-            task: ClassificationTask = t.cast(ClassificationTask, dataset_metadata.task)
+            task: ClassificationTask = cast(ClassificationTask, dataset_metadata.task)
             params["num_class"] = task.num_classes
         if gpu_available():
             params["device"] = "GPU"

--- a/training/xtime/estimators/_rapids.py
+++ b/training/xtime/estimators/_rapids.py
@@ -16,7 +16,6 @@
 import copy
 import logging
 import pickle
-import typing as t
 from pathlib import Path
 
 import pandas as pd
@@ -48,7 +47,7 @@ logger = logging.getLogger(__name__)
 class RandomForestEstimator(Estimator):
     NAME = "rapids-rf"
 
-    def __init__(self, params: t.Dict, dataset_metadata: DatasetMetadata) -> None:
+    def __init__(self, params: dict, dataset_metadata: DatasetMetadata) -> None:
         super().__init__()
         params = copy.deepcopy(params)
         if "n_streams" not in params:

--- a/training/xtime/estimators/_sklearn.py
+++ b/training/xtime/estimators/_sklearn.py
@@ -16,7 +16,6 @@
 
 import copy
 import pickle
-import typing as t
 from pathlib import Path
 
 from sklearn.dummy import DummyClassifier, DummyRegressor
@@ -32,7 +31,7 @@ from ..errors import DatasetError
 
 
 class ScikitLearnEstimator(Estimator):
-    def __init__(self, params: t.Dict, dataset_metadata: DatasetMetadata, classifier_cls, regressor_cls) -> None:
+    def __init__(self, params: dict, dataset_metadata: DatasetMetadata, classifier_cls, regressor_cls) -> None:
         super().__init__()
         params = copy.deepcopy(params)
 
@@ -53,12 +52,12 @@ class ScikitLearnEstimator(Estimator):
 class DummyEstimator(ScikitLearnEstimator):
     NAME = "dummy"
 
-    def __init__(self, params: t.Dict, dataset_metadata: DatasetMetadata) -> None:
+    def __init__(self, params: dict, dataset_metadata: DatasetMetadata) -> None:
         super().__init__(params, dataset_metadata, DummyClassifier, DummyRegressor)
 
 
 class RandomForestEstimator(ScikitLearnEstimator):
     NAME = "rf"
 
-    def __init__(self, params: t.Dict, dataset_metadata: DatasetMetadata) -> None:
+    def __init__(self, params: dict, dataset_metadata: DatasetMetadata) -> None:
         super().__init__(params, dataset_metadata, RandomForestClassifier, RandomForestRegressor)

--- a/training/xtime/estimators/_xgboost.py
+++ b/training/xtime/estimators/_xgboost.py
@@ -15,7 +15,6 @@
 ###
 import copy
 import logging
-import typing as t
 from pathlib import Path
 
 try:
@@ -46,14 +45,14 @@ class XGBoostEstimator(Estimator):
 
     NAME = "xgboost"
 
-    OBJECTIVES: t.Dict[TaskType, str] = {
+    OBJECTIVES: dict[TaskType, str] = {
         # Logistic Regression for binary classification, output probability.
         TaskType.BINARY_CLASSIFICATION: "binary:logistic",
         TaskType.MULTI_CLASS_CLASSIFICATION: "multi:softproba",
         TaskType.REGRESSION: "reg:squarederror",
     }
 
-    EVAL_METRICS: t.Dict[TaskType, t.List[str]] = {
+    EVAL_METRICS: dict[TaskType, list[str]] = {
         # `error`: 1.0 - accuracy, `log_Loss`: negative log likelihood
         TaskType.BINARY_CLASSIFICATION: ["error", "logloss"],
         # `merror`: 1.0 - accuracy, `mlogloss`: cross entropy loss
@@ -61,7 +60,7 @@ class XGBoostEstimator(Estimator):
         TaskType.REGRESSION: ["rmse"],
     }
 
-    def __init__(self, params: t.Dict, dataset_metadata: DatasetMetadata) -> None:
+    def __init__(self, params: dict, dataset_metadata: DatasetMetadata) -> None:
         super().__init__()
         params = copy.deepcopy(params)
         params.update(

--- a/training/xtime/hparams/recommender.py
+++ b/training/xtime/hparams/recommender.py
@@ -15,7 +15,6 @@
 ###
 
 import math
-import typing as t
 
 from ray import tune
 from tinydb import Query, TinyDB
@@ -94,7 +93,7 @@ class DefaultRecommender(object):
             ]
         )
 
-    def recommend(self, query: Query) -> t.List[HParamsSpec]:
+    def recommend(self, query: Query) -> list[HParamsSpec]:
         """Recommend hyperparameters for a given query.
 
         Args:
@@ -104,13 +103,13 @@ class DefaultRecommender(object):
         Returns:
             List of hyperparameter specifications.
         """
-        matches: t.List[t.Dict] = self._db.search(query)
+        matches: list[dict] = self._db.search(query)
         return [match["params"] for match in matches]
 
-    def recommend_default_values(self, query: Query) -> t.List[HParams]:
-        matches: t.List[HParamsSpec] = self.recommend(query)
+    def recommend_default_values(self, query: Query) -> list[HParams]:
+        matches: list[HParamsSpec] = self.recommend(query)
         return [match.default() for match in matches]
 
-    def recommend_search_space(self, query: Query) -> t.List[HParamsSpace]:
-        matches: t.List[HParamsSpec] = self.recommend(query)
+    def recommend_search_space(self, query: Query) -> list[HParamsSpace]:
+        matches: list[HParamsSpec] = self.recommend(query)
         return [match.space() for match in matches]

--- a/training/xtime/io.py
+++ b/training/xtime/io.py
@@ -16,8 +16,8 @@
 
 import json
 import logging
-import typing as t
 from pathlib import Path, WindowsPath
+from typing import Any, Iterable
 
 import mlflow
 import numpy as np
@@ -31,10 +31,10 @@ __all__ = ["encode", "PathLike", "to_path", "IO"]
 logger = logging.getLogger(__name__)
 
 
-PathLike = t.Union[str, Path]
+PathLike = str | Path
 
 
-def to_path(path: t.Union[str, Path], check_is_file: bool = False) -> Path:
+def to_path(path: str | Path, check_is_file: bool = False) -> Path:
     if isinstance(path, str):
         path = Path(path)
     if not isinstance(path, Path):
@@ -47,11 +47,11 @@ def to_path(path: t.Union[str, Path], check_is_file: bool = False) -> Path:
     return path
 
 
-def encode(obj: t.Any) -> t.Any:
+def encode(obj: Any) -> Any:
     """General purpose encoder to encode object recursively to JSON / YAML serializable format."""
     if isinstance(obj, (list, tuple)):
         return [encode(item) for item in obj]
-    if isinstance(obj, t.Dict):
+    if isinstance(obj, dict):
         return {key: encode(value) for key, value in obj.items()}
     if isinstance(obj, (Path, WindowsPath)):
         return obj.as_posix()
@@ -64,7 +64,7 @@ def encode(obj: t.Any) -> t.Any:
     return obj
 
 
-def _object_to_debug_str(obj: t.Any) -> str:
+def _object_to_debug_str(obj: Any) -> str:
     """Convert object to a string containing type information for object values.
     Args:
         obj: Object to return type information for.
@@ -73,7 +73,7 @@ def _object_to_debug_str(obj: t.Any) -> str:
     """
     if isinstance(obj, (list, tuple)):
         return str([_object_to_debug_str(item) for item in obj])
-    elif isinstance(obj, t.Dict):
+    elif isinstance(obj, dict):
         return str({key: _object_to_debug_str(value) for key, value in obj.items()})
     else:
         return str(type(obj))
@@ -89,7 +89,7 @@ class IO(object):
                 file.write(chunk)
 
     @staticmethod
-    def get_path(path: t.Optional[t.Union[str, Path]], default_path: t.Union[str, Path]) -> Path:
+    def get_path(path: str | Path | None, default_path: str | Path) -> Path:
         path = path or default_path
         if isinstance(path, str):
             path = Path(path)
@@ -97,13 +97,13 @@ class IO(object):
 
     @staticmethod
     def work_dir() -> Path:
-        active_run: t.Optional[mlflow.ActiveRun] = mlflow.active_run()
+        active_run: mlflow.ActiveRun | None = mlflow.active_run()
         if active_run is not None:
             return Path(local_file_uri_to_path(active_run.info.artifact_uri))
         return Path.cwd()
 
     @staticmethod
-    def load_yaml(file_path: t.Union[str, Path]) -> t.Any:
+    def load_yaml(file_path: str | Path) -> Any:
         """Load YAML file.
 
         Args:
@@ -115,7 +115,7 @@ class IO(object):
             return yaml.load(stream, Loader=yaml.SafeLoader)
 
     @staticmethod
-    def load_json(file_path: t.Union[str, Path]) -> t.Any:
+    def load_json(file_path: str | Path) -> Any:
         """Load JSON file.
 
         Args:
@@ -127,7 +127,7 @@ class IO(object):
             return json.load(stream)
 
     @staticmethod
-    def load_dict(file_path: PathLike, expected_keys: t.Optional[t.Iterable] = None) -> t.Dict:
+    def load_dict(file_path: PathLike, expected_keys: Iterable | None = None) -> dict:
         """Load dictionary from a file.
 
         Args:
@@ -138,12 +138,12 @@ class IO(object):
             Python dictionary.
         """
         file_path = to_path(file_path)
-        _dict: t.Optional[t.Union] = None
+        _dict: dict | None = None
         if file_path.suffix in (".yaml", ".yml"):
             _dict = IO.load_yaml(file_path)
         elif file_path.suffix == ".json":
             _dict = IO.load_json(file_path)
-        if not isinstance(_dict, t.Dict):
+        if not isinstance(_dict, dict):
             raise ValueError(f"File content is not a dict (file_path={file_path}, content_type={type(_dict)})")
 
         if expected_keys is not None:
@@ -154,7 +154,7 @@ class IO(object):
         return _dict
 
     @staticmethod
-    def save_yaml(data: t.Any, file_path: t.Union[str, Path], raise_on_error: bool = True) -> None:
+    def save_yaml(data: Any, file_path: str | Path, raise_on_error: bool = True) -> None:
         try:
             with open(file_path, "w") as stream:
                 yaml.dump(data, stream, Dumper=yaml.SafeDumper)
@@ -169,7 +169,7 @@ class IO(object):
                 raise
 
     @staticmethod
-    def save_json(data: t.Any, file_path: t.Union[str, Path], raise_on_error: bool = True) -> None:
+    def save_json(data: Any, file_path: str | Path, raise_on_error: bool = True) -> None:
         try:
             with open(file_path, "w") as stream:
                 json.dump(data, stream)
@@ -184,7 +184,7 @@ class IO(object):
                 raise
 
     @staticmethod
-    def save_data_frame(df: pd.DataFrame, file_path: t.Union[str, Path]) -> None:
+    def save_data_frame(df: pd.DataFrame, file_path: str | Path) -> None:
         name: str = to_path(file_path).name
         if name.endswith(".yaml"):
             IO.save_yaml(df.to_dict("records"), file_path)
@@ -196,7 +196,7 @@ class IO(object):
             df.to_csv(file_path)
 
     @staticmethod
-    def save_to_file(data: t.Any, file_name: str) -> None:
+    def save_to_file(data: Any, file_name: str) -> None:
         if isinstance(data, pd.DataFrame):
             IO.save_data_frame(data, file_name)
         elif file_name.endswith(".yaml"):
@@ -207,7 +207,7 @@ class IO(object):
             raise NotImplementedError(f"Do not know how to serialize `{type(data)}` to `{file_name}`.")
 
     @staticmethod
-    def print(data: t.Any) -> None:
+    def print(data: Any) -> None:
         if isinstance(data, dict):
             print(json.dumps(data, indent=4, sort_keys=True))
         elif isinstance(data, pd.DataFrame):

--- a/training/xtime/main.py
+++ b/training/xtime/main.py
@@ -17,7 +17,6 @@
 import json
 import logging
 import sys
-import typing as t
 from multiprocessing import Process
 from pathlib import Path
 
@@ -75,7 +74,7 @@ def _run_search_hp_pipeline(
     dataset: str,
     model: str,
     algorithm: str,
-    hparams: t.Optional[t.Tuple[str]],
+    hparams: tuple | None,
     num_search_trials: int,
     num_validate_trials: int = 0,
     gpu: float = 0,
@@ -104,7 +103,7 @@ def _run_search_hp_pipeline(
     "[Logging Levels]({log_level}) for more details). Only messages with this logging level or higher are "
     "logged.".format(log_level="https://docs.python.org/3/library/logging.html#logging-levels"),
 )
-def cli(log_level: t.Optional[str]):
+def cli(log_level: str | None):
     if log_level:
         log_level = log_level.upper()
         logging.basicConfig(level=log_level)
@@ -128,7 +127,7 @@ def experiments() -> None: ...
 @dataset_arg
 @model_arg
 @params_option
-def experiment_train(dataset: str, model: str, params: t.Tuple[str]) -> None:
+def experiment_train(dataset: str, model: str, params: tuple[str, ...]) -> None:
     from xtime.stages.train import train
 
     try:
@@ -185,7 +184,7 @@ def experiment_search_hp(
     dataset: str,
     model: str,
     algorithm: str,
-    params: t.Tuple[str],
+    params: tuple[str, ...],
     num_search_trials: int,
     num_validate_trials: int = 0,
     gpu: float = 0,
@@ -253,7 +252,7 @@ def experiment_search_hp(
     help="Optional file name for report. The file extension defines serialization format. If not present, generated "
     "report will be printed on a console.",
 )
-def experiment_describe(report_type: str, run: t.Optional[str] = None, file: t.Optional[str] = None) -> None:
+def experiment_describe(report_type: str, run: str | None = None, file: str | None = None) -> None:
     from xtime.stages.describe import describe
 
     try:
@@ -279,7 +278,7 @@ def datasets() -> None: ...
 def dataset_describe(dataset: str, verbose: bool, format_: str) -> None:
     try:
         ds: Dataset = Dataset.create(dataset).validate()
-        summary: t.Dict = ds.summary(verbose=verbose)
+        summary: dict = ds.summary(verbose=verbose)
 
         if format_ == "json":
             json.dump(summary, sys.stdout, indent=4)
@@ -288,8 +287,8 @@ def dataset_describe(dataset: str, verbose: bool, format_: str) -> None:
 
             yaml.dump(summary, sys.stdout)
         else:
-            metadata: t.Dict = summary.pop("metadata")
-            features: t.List[t.Dict] = metadata.pop("features")
+            metadata: dict = summary.pop("metadata")
+            features: list[dict] = metadata.pop("features")
 
             print("METADATA (general)")
             json.dump(metadata, sys.stdout, indent=4)
@@ -370,11 +369,11 @@ def hparams() -> None: ...
 
 @hparams.command("query", help="Query hyperparameters for a given set of input specifications.")
 @params_option
-def hparams_query(params: t.Tuple[str]) -> None:
+def hparams_query(params: tuple[str, ...]) -> None:
     try:
         import xtime.hparams as hp
 
-        hp_dict: t.Dict = hp.get_hparams(params)
+        hp_dict: dict = hp.get_hparams(params)
         json.dump(hp_dict, sys.stdout, indent=4, cls=hp.JsonEncoder)
         print("")
     except Exception as err:

--- a/training/xtime/registry.py
+++ b/training/xtime/registry.py
@@ -17,8 +17,8 @@
 import importlib
 import inspect
 import logging
-import typing as t
 from pathlib import Path
+from typing import Any
 
 from xtime.errors import XTimeError, maybe_suggest_debug_level
 
@@ -50,7 +50,7 @@ class ClassRegistry(object):
         self._path = path.resolve()
         self._module = module
         self._initialized = False
-        self._registry: t.Dict[str, t.Type] = {}
+        self._registry: dict[str, type] = {}
 
     def contains(self, name: str) -> bool:
         """Check if a class with the given name is registered in the registry."""
@@ -62,7 +62,7 @@ class ClassRegistry(object):
         self._maybe_init()
         return self._registry.get(name)
 
-    def keys(self) -> t.List[str]:
+    def keys(self) -> list[str]:
         self._maybe_init()
         return list(self._registry.keys())
 
@@ -128,7 +128,7 @@ class ClassRegistry(object):
 
         self._initialized = True
 
-    def _register(self, name: str, registrable: t.Any, module) -> None:
+    def _register(self, name: str, registrable: Any, module) -> None:
         if name in self._registry:
             raise ValueError(
                 f"Object with name ({name}) from module {module} already exists in registry ({self._registry[name]}). "

--- a/training/xtime/run.py
+++ b/training/xtime/run.py
@@ -15,7 +15,6 @@
 ###
 
 import copy
-import typing as t
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -61,9 +60,9 @@ class Metadata:
     dataset: str
     model: str
     run_type: RunType
-    fit_params: t.Dict = field(default_factory=dict)
+    fit_params: dict = field(default_factory=dict)
 
-    def to_json(self) -> t.Dict:
+    def to_json(self) -> dict:
         return {
             "dataset": self.dataset,
             "model": self.model,
@@ -77,6 +76,6 @@ class Context:
     """Context for a run."""
 
     metadata: Metadata
-    dataset: t.Optional[Dataset] = None
+    dataset: Dataset | None = None
     # FIXME sergey: this needs to be fixed.
-    callbacks: t.Optional[t.List["Callback"]] = None  # noqa: F821
+    callbacks: list["Callback"] | None = None  # noqa: F821

--- a/training/xtime/stages/describe.py
+++ b/training/xtime/stages/describe.py
@@ -14,21 +14,19 @@
 # limitations under the License.
 ###
 
-import typing as t
-
 import pandas as pd
 
 from xtime.contrib.tune_ext import Analysis
 from xtime.io import IO
 
 
-def describe(report_type: str, run: t.Optional[str] = None, file: t.Optional[str] = None) -> None:
+def describe(report_type: str, run: str | None = None, file: str | None = None) -> None:
     """Describe experiment with `REPORT_TYPE` report stored as MLflow `RUN` run, optionally save to `OUTPUT` file."""
     if report_type in ("summary", "best_trial") and run is None:
         print("When report type is `summary` or `best_trial`, MLflow run ID must be provided (--run=RUN_ID).")
         exit(1)
 
-    summary: t.Optional[t.Union[t.Dict, pd.DataFrame]] = None
+    summary: dict | pd.DataFrame | None = None
     if report_type == "summary":
         assert run is not None, "The `run` can't be none here."
         summary = Analysis.get_summary(run)

--- a/training/xtime/stages/train.py
+++ b/training/xtime/stages/train.py
@@ -16,7 +16,6 @@
 
 import logging
 import sys
-import typing as t
 
 import mlflow
 
@@ -31,7 +30,7 @@ from xtime.run import Context, Metadata, RunType
 logger = logging.getLogger(__name__)
 
 
-def train(dataset: str, model: str, hparams: t.Optional[HParamsSource]) -> None:
+def train(dataset: str, model: str, hparams: HParamsSource | None) -> None:
     """Train a model for a given problem using default, HP-optimized or pre-defined parameters.
 
     Enable GPUs by setting CUDA_VISIBLE_DEVICES variable (e.g., CUDA_VISIBLE_DEVICES=0 python -m xtime ...).
@@ -53,9 +52,9 @@ def train(dataset: str, model: str, hparams: t.Optional[HParamsSource]) -> None:
             hparams = f"auto:default:model={model};task={context.dataset.metadata.task.type.value};run_type=train"
             logger.info("Hyperparameters are not provided, using default ones: '%s'.", hparams)
 
-        hp_dict: t.Dict = get_hparams(hparams)
+        hp_dict: dict = get_hparams(hparams)
         logger.info("Hyperparameters resolved to: '%s'", hp_dict)
 
-        estimator: t.Type[Estimator] = get_estimator(model)
+        estimator: type[Estimator] = get_estimator(model)
         _ = estimator.fit(hp_dict, context)
         print(f"MLflowRun uri=mlflow:///{active_run.info.run_id}")


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Many of annotations from the `typing` package are replaced with types (e.g., `typing.Dict` -> `dict`).

# What changes are proposed in this pull request?

- [x] Refactoring

# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [x] If applicable, new and existing unit tests pass locally with my changes.

